### PR TITLE
Introduce caching strategy

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Immutable = require('immutable');
+
 var AllDependencies = {
   _graph: {},
 
@@ -21,12 +23,11 @@ var AllDependencies = {
 
     // for() was passed a package name
     if (this._graph[fileOrPackage]) {
-      return this._graph[fileOrPackage];
+      return Immutable.fromJS(this._graph[fileOrPackage]);
     }
 
     // for() was passed a file path
-    return this._graph[packageName][fileOrPackage].imports;
-
+    return Immutable.fromJS(this._graph[packageName][fileOrPackage].imports);
   }
 };
 

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -18,7 +18,7 @@ var AllDependencies = {
     var packageName = parts[0];
 
     if (!this._graph[packageName]) {
-      return null;
+      return Immutable.Map();
     }
 
     // for() was passed a package name
@@ -27,7 +27,11 @@ var AllDependencies = {
     }
 
     // for() was passed a file path
-    return Immutable.fromJS(this._graph[packageName][fileOrPackage].imports);
+    if (this._graph[packageName][fileOrPackage]) {
+      return Immutable.fromJS(this._graph[packageName][fileOrPackage].imports);
+    }
+    
+    return Immutable.List();
   }
 };
 

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -75,9 +75,11 @@ module.exports = CoreObject.extend({
     };
   },
 
-  syncForwardDependencies: function(destination, dep) {
-    fs.mkdirsSync(path.dirname(destination));
-    symlinkOrCopySync(dep, destination);
+  syncForwardDependencies: function(destination, dependency) {
+    if (!fs.existsSync(destination)) {
+      fs.mkdirsSync(path.dirname(destination));
+      symlinkOrCopySync(dependency, destination);
+    }
   },
 
   /**
@@ -116,18 +118,13 @@ module.exports = CoreObject.extend({
       entry = self._getEntry(imprt);
       imprt = imprt + '.js';
 
-      var dep = path.join(srcDir, imprt);
       var depGraph = path.join(srcDir, entry, 'dep-graph.json');
 
-      if (!fs.existsSync(path.join(destDir, imprt))) {
+      if (!self.checkCache(entry, depGraph)) {
+        var dependency = path.join(srcDir, imprt);
         var destination = path.join(destDir, imprt);
-
-        self.syncForwardDependencies(destination, dep);
-
-        if (!self.checkCache(entry, depGraph)) {
-          self.resolve(srcDir, destDir, AllDependencies.for(imprt));
-        }
-
+        self.syncForwardDependencies(destination, dependency);
+        self.resolve(srcDir, destDir, AllDependencies.for(imprt));
       }
     });
   },

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -36,19 +36,34 @@ module.exports = CoreObject.extend({
     });
   },
 
+  checkCache: function(entry, graphPath) {
+    var existingGraph = AllDependencies.for(entry);
+    var newGraph = Immutable.fromJS(fs.readJSONSync(graphPath));
+
+    if (existingGraph !== newGraph) {
+      this.updateGraph(entry, graphPath);
+      return false;
+    }
+
+    return true;
+  },
+
   resolveEntries: function(srcDir, destDir) {
     var self = this;
     var paths = walkSync(srcDir);
 
     this.entries.forEach(function(entry) {
       var entryDepGraphPath = path.join(srcDir, entry, 'dep-graph.json');
+      var cacheValid = self.checkCache(entry, entryDepGraphPath);
 
-      // Sync the entry
-      paths.filter(self._isEntryFiles(entry)).forEach(function(relativePath) {
-        self.syncForwardDependencies(path.join(destDir, relativePath), path.join(srcDir, relativePath));
-      });
+      if (!cacheValid) {
+        // Sync the entry
+        paths.filter(self._isEntryFiles(entry)).forEach(function(relativePath) {
+          self.syncForwardDependencies(path.join(destDir, relativePath), path.join(srcDir, relativePath));
+        });
 
-      self.resolve(srcDir, destDir, self.flattenEntryImports(entry, entryDepGraphPath));
+        self.resolve(srcDir, destDir, self.flattenEntryImports(entry, entryDepGraphPath));
+      }
     });
 
     return destDir;
@@ -73,8 +88,7 @@ module.exports = CoreObject.extend({
    * @param  {String} graphPath The path to dep-graph.json
    * @return {Array}            The direct dependencies for the entry
    */
-  flattenEntryImports: function(entry, graphPath) {
-    this.updateGraph(entry, graphPath);
+  flattenEntryImports: function(entry) {
     return Immutable.Set(AllDependencies.for(entry).keySeq().flatMap(function(file) {
       return AllDependencies.for(file);
     }));

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -124,10 +124,7 @@ module.exports = CoreObject.extend({
 
         self.syncForwardDependencies(destination, dep);
 
-        if (!AllDependencies.for(entry)) {
-          self.updateGraph(entry, depGraph);
-          // We now look at the direct path to resolve all the
-          // transitive dependencies.
+        if (!self.checkCache(entry, depGraph)) {
           self.resolve(srcDir, destDir, AllDependencies.for(imprt));
         }
 

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -7,9 +7,8 @@ var walkSync          = require('walk-sync');
 var path              = require('path');
 var symlinkOrCopySync = require('symlink-or-copy').sync;
 var quickTemp         = require('quick-temp');
-var uniq              = require('lodash-node/modern/array/uniq');
-var flatten           = require('lodash-node/modern/array/flatten');
 var fs                = require('fs-extra');
+var Immutable         = require('immutable');
 
 module.exports = CoreObject.extend({
   init: function(inputTree, options) {
@@ -76,9 +75,9 @@ module.exports = CoreObject.extend({
    */
   flattenEntryImports: function(entry, graphPath) {
     this.updateGraph(entry, graphPath);
-    return uniq(flatten(Object.keys(AllDependencies.for(entry)).map(function(file) {
+    return Immutable.Set(AllDependencies.for(entry).keySeq().flatMap(function(file) {
       return AllDependencies.for(file);
-    })));
+    }));
   },
 
   updateGraph: function(entry, graphPath) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "core-object": "^1.1.0",
     "fs-extra": "^0.17.0",
+    "immutable": "^3.7.0",
     "lodash-node": "^3.6.0",
     "quick-temp": "^0.1.2",
     "rsvp": "^3.0.18",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "broccoli-stew": "^0.2.1",
-    "broccoli-test-helpers": "0.0.4",
+    "broccoli-test-helpers": "0.0.5",
     "chai": "^2.2.0",
     "mocha": "^2.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Provides pre-packaging for Ember CLI applcations",
   "main": "lib/pre-packager.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha -R nyan tests/**/*-test.js"
+    "test": "./node_modules/.bin/mocha -R spec tests/**/*-test.js"
   },
   "keywords": [
     "ember-cli"

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -87,4 +87,34 @@ describe('pre-package acceptance', function () {
 
     });
   });
+
+  it('should have edits to a file', function () {
+    var initializer = path.join(process.cwd(), '/example-app/initializers/ember-moment.js');
+
+
+    return prePackager(find('.'), {
+      entries: ['example-app']
+    }).then(function(results) {
+      expect(results.files).to.deep.equal([
+        'ember-moment/helpers/ago.js',
+        'ember-moment/helpers/duration.js',
+        'ember-moment/helpers/moment.js',
+        'example-app/app.js',
+        'example-app/config/environment.js',
+        'example-app/initializers/ember-moment.js',
+        'example-app/router.js'
+      ]);
+
+      // Simulate edit
+      fs.writeFileSync(initializer, 'var a = "a";');
+
+      return results.builder();
+    }).then(function(results) {
+
+      var changedFile = fs.readFileSync(path.join(results.directory, 'example-app/initializers/ember-moment.js'), 'utf8');
+
+      expect(changedFile).to.equal('var a = "a";');
+      fs.writeFileSync(initializer, '');
+    });
+  });
 });

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -49,7 +49,7 @@ describe('pre-package acceptance', function () {
     });
   });
 
-  it('rebuilds when an addon changes imports', function () {
+  it('should remove files from the output if the imports are removed', function () {
     var graphPath = path.join(process.cwd(), 'tests/fixtures/example-app/dep-graph.json');
     var appDepGraph = Immutable.fromJS(fs.readJSONSync(graphPath));
     var initializer = path.join(process.cwd(), '/tests/fixtures/example-app/initializers/ember-moment.js');

--- a/tests/fixtures/example-app/dep-graph.json
+++ b/tests/fixtures/example-app/dep-graph.json
@@ -7,9 +7,7 @@
       "ember/load-initializers",
       "example-app/config/environment"
     ],
-    "exports": [
-      "NOT IMPLEMENTED YET"
-    ]
+    "exports": ["NOT IMPLEMENTED YET"]
   },
   "example-app/initializers/ember-moment.js": {
     "imports": [
@@ -19,9 +17,7 @@
       "ember-moment/helpers/duration",
       "ember"
     ],
-    "exports": [
-      "NOT IMPLEMENTED YET"
-    ]
+    "exports": ["NOT IMPLEMENTED YET"]
   },
   "example-app/router.js": {
     "imports": [
@@ -29,8 +25,6 @@
       "ember",
       "example-app/config/environment"
     ],
-    "exports": [
-      "NOT IMPLEMENTED YET"
-    ]
+    "exports": ["NOT IMPLEMENTED YET"]
   }
 }

--- a/tests/fixtures/example-app/dep-graph.json
+++ b/tests/fixtures/example-app/dep-graph.json
@@ -7,7 +7,9 @@
       "ember/load-initializers",
       "example-app/config/environment"
     ],
-    "exports": ["NOT IMPLEMENTED YET"]
+    "exports": [
+      "NOT IMPLEMENTED YET"
+    ]
   },
   "example-app/initializers/ember-moment.js": {
     "imports": [
@@ -17,7 +19,9 @@
       "ember-moment/helpers/duration",
       "ember"
     ],
-    "exports": ["NOT IMPLEMENTED YET"]
+    "exports": [
+      "NOT IMPLEMENTED YET"
+    ]
   },
   "example-app/router.js": {
     "imports": [
@@ -25,6 +29,8 @@
       "ember",
       "example-app/config/environment"
     ],
-    "exports": ["NOT IMPLEMENTED YET"]
+    "exports": [
+      "NOT IMPLEMENTED YET"
+    ]
   }
 }

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -4,6 +4,7 @@ var AllDependencies = require('../../lib/all-dependencies');
 var expect = require('chai').expect;
 var fs = require('fs-extra');
 var depGraph = fs.readJSONSync('./tests/fixtures/example-app/dep-graph.json');
+var Immutable = require('immutable');
 
 describe('all dependencies unit', function() {
 
@@ -14,7 +15,7 @@ describe('all dependencies unit', function() {
   describe('update', function () {
     it('should place a package into dep-graph keyed off of the package name', function() {
       AllDependencies.update('example-app', depGraph);
-      expect(AllDependencies._graph['example-app']).to.be.an('object');
+      expect(AllDependencies._graph['example-app']).to.deep.equal(depGraph);
       expect(AllDependencies._graph['example-app']).to.deep.equal(depGraph);
     });
 
@@ -30,19 +31,19 @@ describe('all dependencies unit', function() {
   describe('for', function() {
     it('should return a graph for a package', function() {
       AllDependencies.update('example-app', depGraph);
-      expect(AllDependencies.for('example-app')).to.deep.equal(depGraph);
+      expect(AllDependencies.for('example-app')).to.deep.equal(Immutable.fromJS(depGraph));
     });
 
     it('should return the imports for a specific file', function() {
       AllDependencies.update('example-app', depGraph);
       var imports = AllDependencies.for('example-app/initializers/ember-moment.js');
-      expect(imports).to.deep.equal([
+      expect(imports).to.deep.equal(Immutable.List.of(
         'exports',
         'ember-moment/helpers/moment',
         'ember-moment/helpers/ago',
         'ember-moment/helpers/duration',
         'ember'
-      ]);
+      ));
     });
 
     it('should return null if the package graph is not foudn', function() {

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -46,9 +46,9 @@ describe('all dependencies unit', function() {
       ));
     });
 
-    it('should return null if the package graph is not foudn', function() {
+    it('should return an empty Map if the package graph is not foudn', function() {
       var imports = AllDependencies.for('example-moment/ago.js');
-      expect(imports).to.equal(null);
+      expect(imports).to.deep.equal(Immutable.Map());
     });
   });
 });


### PR DESCRIPTION
This commit introduces the caching strategy for the pre-packager.
Instead of taking the approach seen in ember-browserify, I have
opted to use immutable objects which have change tracking and
reference equality.  The advantage to this is that we compare the
actual data structure instead of a hash.  We can then check for
idempotency of each import branch and only re-sync that
portion of the graph.

Currently this re-syncs everything in the changed graph.
