### PR TITLE
NPM Cache Invalidation

### DIFF
--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -13,6 +13,16 @@ function generateStub(moduleName) {
          '});';
 }
 
+function hashPackage(srcDir, pkg) {
+  var pkgPath = path.join(srcDir, 'node_modules', pkg);
+
+  return helpers.hashStrings(walkSync(pkgPath).filter(function(relativePath) {
+    return relativePath.slice(-1) !== '/';
+  }).map(function(relativePath) {
+    return fs.readFileSync(path.join(pkgPath, relativePath), 'utf8');
+  }));
+}
+
 module.exports = {
   files: {},
   stubCache: {},
@@ -54,19 +64,10 @@ module.exports = {
 
   checkGraphCache: function(srcDir, pkg) {
     var isGraphCacheValid = true;
+    var hash = hashPackage(srcDir, pkg);
 
-    if (!this.graph[pkg]) {
-      var pkgPath = path.join(srcDir, 'node_modules', pkg);
-
-      var paths = walkSync(pkgPath).filter(function(relativePath) {
-        return relativePath.slice(-1) !== '/';
-      });
-
-      var strings = paths.map(function(relativePath) {
-        return fs.readFileSync(path.join(pkgPath, relativePath), 'utf8');
-      }, this);
-
-      this.graph[pkg] = helpers.hashStrings(strings);
+    if (!this.graph[pkg] || this.graph[pkg] !== hash) {
+      this.graph[pkg] = hash;
       isGraphCacheValid = false;
     }
     


### PR DESCRIPTION
We also need to make sure to check to see if anything in the
package has changed. This will be needed if you `npm link` a
legacy script to the consuming application.
