### PR TITLE
Ensure Browserify Is Lazy

### DIFF
--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -2,6 +2,11 @@
 
 var AllDependencies         = require('./all-dependencies');
 var syncForwardDependencies = require('./sync-forward-dependencies');
+var utils                   = require('./utils');
+var uniq                    = utils.uniq;
+var flatMap                 = utils.flatMap;
+var isEntryFiles            = utils.isEntryFiles;
+var importType              = utils.importType;
 var CoreObject              = require('core-object');
 var RSVP                    = require('rsvp');
 var walkSync                = require('walk-sync');
@@ -10,52 +15,13 @@ var quickTemp               = require('quick-temp');
 var fs                      = require('fs-extra');
 var mapSeries               = require('promise-map-series');
 
-function uniq(arr) {
-  return arr.reduce(function(a, b) {
-    if (a.indexOf(b) < 0) {
-      a.push(b);
-    }
-    return a;
-  }, []);
-}
-
-function flatten(arr) {
-  return arr.reduce(function(a, b) {
-    return a.concat(b);
-  });
-}
-
-function flatMap(arr, fn) {
-  return flatten(arr.map(fn));
-}
-
-function isEntryFiles(entry) {
-  return function(relativePath) {
-    return relativePath.indexOf(entry) > -1 && relativePath.slice(-1) !== '/' && relativePath.indexOf('dep-graph.json') < 0;
-  };
-}
-
-function importType(imprt) {
-  var importParts = imprt.split(':');
-  var type = {};
-
-  if (importParts.length > 1) {
-    type.type = importParts[0];
-    type.id = importParts[1];
-  } else {
-    type.type = 'default';
-    type.id = imprt;
-  }
-
-  return type;
-}
-
 module.exports = CoreObject.extend({
   init: function(inputTree, options) {
     var defaultResolvers = ['default', 'npm'];
     this.resolvers = {};
     this.inputTree = inputTree;
     this.options = options || {};
+    this.importCache = null;
 
     if (!this.options.entries) {
       throw new Error('You must pass an array of entries.');
@@ -99,6 +65,8 @@ module.exports = CoreObject.extend({
   resolveEntries: function(srcDir, destDir) {
     var paths = walkSync(srcDir);
 
+    this.importCache = {};
+
     return RSVP.Promise.all(this.entries.map(function(entry) {
       var entryDepGraphPath = fs.readJSONSync(path.join(srcDir, entry, 'dep-graph.json'));
 
@@ -110,7 +78,19 @@ module.exports = CoreObject.extend({
 
       return this.selectResolution(srcDir, destDir, this.flattenEntryImports(entry, entryDepGraphPath));
       
-    }, this));
+    }, this)).finally(function () {
+
+      return RSVP.Promise.all(Object.keys(this.resolvers).map(function(resolver) {
+        var resolveLazily = this.resolvers[resolver].resolveLazily;
+        var importCache = this.importCache[resolver];
+
+        if (resolveLazily && importCache) {
+          return resolveLazily.call(this.resolvers[resolver], srcDir, destDir, importCache);
+        }
+
+        return RSVP.Promise.resolve();
+      }, this));
+    }.bind(this));
   },
 
   /**
@@ -140,6 +120,16 @@ module.exports = CoreObject.extend({
 
       if (this.resolutionTypes.indexOf(importInfo.type) < 0) {
         throw new Error('You do not have a resolver for ' + importInfo.type + ' types.');
+      }
+
+      if (!this.importCache[importInfo.type]) {
+        this.importCache[importInfo.type] = {};
+      }
+
+      if (!this.importCache[importInfo.type][importInfo.pkg]) {
+        this.importCache[importInfo.type][importInfo.pkg] = [importInfo.id];
+      } else {
+        this.importCache[importInfo.type][importInfo.pkg].push(importInfo.id);
       }
 
       return this.resolvers[importInfo.type].resolve(

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -1,13 +1,16 @@
 'use strict';
 
+var utils      = require('../utils');
+var uniq       = utils.uniq; 
 var RSVP       = require('rsvp');
 var browserify = require('browserify');
 var path       = require('path');
 var helpers    = require('broccoli-kitchen-sink-helpers');
 var fs         = require('fs-extra');
 var walkSync   = require('walk-sync');
+var mapSeries  = require('promise-map-series');
 
-function generateStub(moduleName) {
+function _generateStub(moduleName) {
   return 'define("npm:' + moduleName + '", function() {' +
          'return { "default": require("' + moduleName + '") };' +
          '});';
@@ -24,9 +27,7 @@ function hashPackage(srcDir, pkg) {
 }
 
 module.exports = {
-  files: {},
-  stubCache: {},
-  graph: {},
+  cache: {},
 
   bundler: function(entry) {
     var b = browserify();
@@ -34,7 +35,7 @@ module.exports = {
     return b;
   },
 
-  updateCache: function(entryFile, imprt) {
+  updateCache: function(entryFile, pkg) {
     return new RSVP.Promise(function(resolve, reject) {
       this.bundler(entryFile).bundle(function(err, data) {
 
@@ -42,81 +43,44 @@ module.exports = {
           reject(err);
         }
 
-        // console.log(data.toString());
         fs.mkdirsSync(path.dirname(entryFile));
         fs.writeFileSync(entryFile, data);
 
-        this.files[imprt] = data;
+        this.cache[pkg].buffer = data;
 
         resolve();
       }.bind(this));
     }.bind(this));
   },
 
-  checkStubCache: function(srcDir, entry) {
-    var isStubCacheValid = true;
-
-    if (!this.stubCache[entry]) {
-      isStubCacheValid = false;
-    }
-
-    return isStubCacheValid;
+  resolve: function() {
+    return RSVP.Promise.resolve();
   },
 
-  checkGraphCache: function(srcDir, pkg) {
-    var isGraphCacheValid = true;
-    var hash = hashPackage(srcDir, pkg);
+  resolveLazily: function(srcDir, destDir, imports) {
+    return mapSeries(Object.keys(imports), function(pkg) {
+      var outFile = path.join(destDir, 'browserified', pkg, pkg + '.js');
+      var stub = uniq(imports[pkg]).map(function(file) {
+                  return _generateStub(file);
+                }).join('');
 
-    if (!this.graph[pkg] || this.graph[pkg] !== hash) {
-      this.graph[pkg] = hash;
-      isGraphCacheValid = false;
-    }
-    
-    return isGraphCacheValid;
-  },
+      fs.mkdirsSync(path.dirname(outFile));
 
-  writeStub: function(destination, imprt) {
-    var generatedStub = generateStub(imprt);
-    fs.mkdirsSync(path.dirname(destination));
-    fs.writeFileSync(destination, generatedStub);
-    this.stubCache[imprt] = generatedStub;
-  },
+      if (!this.cache[pkg] || this.cache[pkg].stub !== stub || this.cache[pkg].hash !== hashPackage(srcDir, pkg)) {
 
-  writeFileFromCache: function(destination, imprt) {
-    fs.mkdirsSync(path.dirname(destination));
-    fs.writeFileSync(destination, this.files[imprt]);
-  },
+        this.cache[pkg] = {
+          stub: stub,
+          hash: hashPackage(srcDir, pkg)
+        };
 
-  writeStubFromCache: function(destination, imprt) {
-    fs.mkdirsSync(path.dirname(destination));
-    fs.writeFileSync(destination, this.stubCache[imprt]);
-  },
+        fs.writeFileSync(outFile, stub);
+        return this.updateCache(outFile, pkg);
+      }
 
-  resolve: function(srcDir, destDir, imprt) {
-    var pkg = imprt.split('/')[0];
-    var outFile;
+      fs.writeFileSync(outFile, this.cache[pkg].buffer);
 
-    if (pkg === imprt) {
-      outFile = path.join(destDir, 'browserified', pkg, 'index.js');
-    } else {
-      outFile = path.join(destDir, 'browserified', pkg, imprt.split('/').splice(1).join('/') + '.js');
-    }
-    
-    // Eh this is probably not needed and only saves a
-    // single IO cycle per node module.
-    if (!this.checkStubCache(srcDir, imprt)) {
-      this.writeStub(path.join(outFile), imprt);
-    } else {
-      this.writeStubFromCache(outFile, imprt);
-    }
+      return RSVP.Promise.resolve();
 
-    if (!this.checkGraphCache(srcDir, imprt)) {
-      return this.updateCache(outFile, imprt).then(function() {
-        return destDir;
-      });
-    }
-
-    this.writeFileFromCache(outFile, imprt);
-    return RSVP.Promise.resolve(destDir);
+    }, this);
   }
 };

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -14,7 +14,7 @@ function generateStub(moduleName) {
 }
 
 function hashPackage(srcDir, pkg) {
-  var pkgPath = path.join(srcDir, 'node_modules', pkg);
+  var pkgPath = path.join(srcDir, 'node_modules', pkg.split('/')[0]);
 
   return helpers.hashStrings(walkSync(pkgPath).filter(function(relativePath) {
     return relativePath.slice(-1) !== '/';
@@ -42,6 +42,7 @@ module.exports = {
           reject(err);
         }
 
+        // console.log(data.toString());
         fs.mkdirsSync(path.dirname(entryFile));
         fs.writeFileSync(entryFile, data);
 
@@ -77,7 +78,7 @@ module.exports = {
   writeStub: function(destination, imprt) {
     var generatedStub = generateStub(imprt);
     fs.mkdirsSync(path.dirname(destination));
-    fs.writeFileSync(destination, generateStub);
+    fs.writeFileSync(destination, generatedStub);
     this.stubCache[imprt] = generatedStub;
   },
 
@@ -93,8 +94,14 @@ module.exports = {
 
   resolve: function(srcDir, destDir, imprt) {
     var pkg = imprt.split('/')[0];
-    var outFile = path.join(destDir, 'browserified', pkg, pkg + '.js');
+    var outFile;
 
+    if (pkg === imprt) {
+      outFile = path.join(destDir, 'browserified', pkg, 'index.js');
+    } else {
+      outFile = path.join(destDir, 'browserified', pkg, imprt.split('/').splice(1).join('/') + '.js');
+    }
+    
     // Eh this is probably not needed and only saves a
     // single IO cycle per node module.
     if (!this.checkStubCache(srcDir, imprt)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,74 @@
+'use strict';
+
+function uniq(arr) {
+  return arr.reduce(function(a, b) {
+    if (a.indexOf(b) < 0) {
+      a.push(b);
+    }
+    return a;
+  }, []);
+}
+
+function flatten(arr) {
+  return arr.reduce(function(a, b) {
+    return a.concat(b);
+  });
+}
+
+function flatMap(arr, fn) {
+  return flatten(arr.map(fn));
+}
+
+function isEntryFiles(entry) {
+  return function(relativePath) {
+    return relativePath.indexOf(entry) > -1 && relativePath.slice(-1) !== '/' && relativePath.indexOf('dep-graph.json') < 0;
+  };
+}
+
+function importType(imprt) {
+  var importParts = imprt.split(':');
+  var type = {};
+
+  if (importParts.length > 1) {
+    type.type = importParts[0];
+    type.id = importParts[1];
+    type.pkg = importParts[1].split('/')[0];
+  } else {
+    type.type = 'default';
+    type.id = imprt;
+    type.pkg = imprt.split('/')[0];
+  }
+
+  return type;
+}
+
+function arraysEqual(a, b) {
+  if (a === b) {
+    return true;
+  }
+
+  if (a === null || b === null) {
+    return false;
+  }
+
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (var i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i]){
+      return false;
+    }
+  }
+
+  return true;
+}
+
+module.exports = {
+  uniq: uniq,
+  flatMap: flatMap,
+  flatten: flatten,
+  isEntryFiles: isEntryFiles,
+  importType: importType,
+  arraysEqual: arraysEqual
+};

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -43,7 +43,8 @@ describe('pre-package acceptance', function () {
       entries: ['example-app']
     }).then(function(results) {
       expect(results.files).to.deep.equal([
-        'browserified/moment/moment.js',
+        'browserified/moment/index.js',
+        'browserified/moment/lib/ago.js',
         'ember/ember.js',
         'ember-load-initializers/ember-load-initializers.js',
         'ember-moment/helpers/ago.js',
@@ -69,7 +70,8 @@ describe('pre-package acceptance', function () {
       entries: ['example-app']
     }).then(function(results) {
       expect(results.files).to.deep.equal([
-        'browserified/moment/moment.js',
+        'browserified/moment/index.js',
+        'browserified/moment/lib/ago.js',
         'ember/ember.js',
         'ember-load-initializers/ember-load-initializers.js',
         'ember-moment/helpers/ago.js',
@@ -133,7 +135,7 @@ describe('pre-package acceptance', function () {
       }).then(function(results) {
         return results.builder();
       }).then(function(results) {
-        expect(results.subject.resolvers.npm.updateCache.callCount).to.equal(1);
+        expect(results.subject.resolvers.npm.updateCache.callCount).to.equal(2);
         results.subject.resolvers.npm.updateCache.restore();
       });
     });
@@ -146,7 +148,7 @@ describe('pre-package acceptance', function () {
         return results.builder();
       }).then(function(results) {
         fs.remove('./node_modules/moment/lib/month.js');
-        expect(results.subject.resolvers.npm.updateCache.callCount).to.equal(2);
+        expect(results.subject.resolvers.npm.updateCache.callCount).to.equal(4);
         results.subject.resolvers.npm.updateCache.restore();
       });
     });

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -43,8 +43,7 @@ describe('pre-package acceptance', function () {
       entries: ['example-app']
     }).then(function(results) {
       expect(results.files).to.deep.equal([
-        'browserified/moment/index.js',
-        'browserified/moment/lib/ago.js',
+        'browserified/moment/moment.js',
         'ember/ember.js',
         'ember-load-initializers/ember-load-initializers.js',
         'ember-moment/helpers/ago.js',
@@ -69,20 +68,6 @@ describe('pre-package acceptance', function () {
     return prePackager(find('.'), {
       entries: ['example-app']
     }).then(function(results) {
-      expect(results.files).to.deep.equal([
-        'browserified/moment/index.js',
-        'browserified/moment/lib/ago.js',
-        'ember/ember.js',
-        'ember-load-initializers/ember-load-initializers.js',
-        'ember-moment/helpers/ago.js',
-        'ember-moment/helpers/duration.js',
-        'ember-moment/helpers/moment.js',
-        'ember-resolver/ember-resolver.js',
-        'example-app/app.js',
-        'example-app/config/environment.js',
-        'example-app/initializers/ember-moment.js',
-        'example-app/router.js'
-      ]);
 
       delete graphClone['example-app/initializers/ember-moment.js'];
 
@@ -116,9 +101,7 @@ describe('pre-package acceptance', function () {
         fixturePath: fixturePath,
         subject: testSubject,
         prepSubject: function(subject) {
-          subject.resolvers.npm.files = {};
-          subject.resolvers.npm.stubCache = {};
-          subject.resolvers.npm.graph = {};
+          subject.resolvers.npm.cache = {};
           sinon.spy(subject.resolvers.npm, 'updateCache');
           return subject;
         }
@@ -129,18 +112,20 @@ describe('pre-package acceptance', function () {
       return cleanupBuilders();
     });
 
-    it('should not re-browserfify if nothing has changed', function() {
+    it('should not re-browserfify if the package has not changed', function() {
       return prePackager(find('.'), {
         entries: ['example-app']
       }).then(function(results) {
         return results.builder();
       }).then(function(results) {
-        expect(results.subject.resolvers.npm.updateCache.callCount).to.equal(2);
+        return results.builder();
+      }).then(function(results) {
+        expect(results.subject.resolvers.npm.updateCache.callCount).to.equal(1);
         results.subject.resolvers.npm.updateCache.restore();
       });
     });
 
-    it('should re-browserfify if something has changed', function() {
+    it('should re-browserfify if the package changed', function() {
       return prePackager(find('.'), {
         entries: ['example-app']
       }).then(function(results) {
@@ -148,7 +133,7 @@ describe('pre-package acceptance', function () {
         return results.builder();
       }).then(function(results) {
         fs.remove('./node_modules/moment/lib/month.js');
-        expect(results.subject.resolvers.npm.updateCache.callCount).to.equal(4);
+        expect(results.subject.resolvers.npm.updateCache.callCount).to.equal(2);
         results.subject.resolvers.npm.updateCache.restore();
       });
     });

--- a/tests/fixtures/ember-moment/dep-graph.json
+++ b/tests/fixtures/ember-moment/dep-graph.json
@@ -38,7 +38,7 @@
     "imports": [
       "exports",
       "ember",
-      "npm:moment"
+      "npm:moment/lib/ago"
     ],
     "exports": [
       "NOT IMPLEMENTED YET"

--- a/tests/fixtures/node_modules/moment/index.js
+++ b/tests/fixtures/node_modules/moment/index.js
@@ -1,3 +1,4 @@
 var ago = require('./lib/ago');
+var time = require('./lib/time');
 
-module.exports = {'ago': ago};
+module.exports = {'ago': ago, 'time': time};

--- a/tests/fixtures/node_modules/moment/lib/time.js
+++ b/tests/fixtures/node_modules/moment/lib/time.js
@@ -1,0 +1,3 @@
+module.exports = {
+  time: 'time'
+};


### PR DESCRIPTION
This refactors NPM resolution to be lazy. Because we need have browserify
to preform the deduping we must first resolve the graph and then build the
browserified bundles.
