### PR TITLE
Rename default resolver to addon resolver

### DIFF
--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -6,7 +6,7 @@ var utils                   = require('./utils');
 var uniq                    = utils.uniq;
 var flatMap                 = utils.flatMap;
 var isEntryFiles            = utils.isEntryFiles;
-var importType              = utils.importType;
+var getImportInfo           = utils.getImportInfo;
 var CoreObject              = require('core-object');
 var RSVP                    = require('rsvp');
 var walkSync                = require('walk-sync');
@@ -17,7 +17,7 @@ var mapSeries               = require('promise-map-series');
 
 module.exports = CoreObject.extend({
   init: function(inputTree, options) {
-    var defaultResolvers = ['default', 'npm'];
+    var defaultResolvers = ['addon', 'npm'];
     this.resolvers = {};
     this.inputTree = inputTree;
     this.options = options || {};
@@ -68,15 +68,15 @@ module.exports = CoreObject.extend({
     this.importCache = {};
 
     return RSVP.Promise.all(this.entries.map(function(entry) {
-      var entryDepGraphPath = fs.readJSONSync(path.join(srcDir, entry, 'dep-graph.json'));
+      var entryDepGraph = fs.readJSONSync(path.join(srcDir, entry, 'dep-graph.json'));
 
-      AllDependencies.update(entry, entryDepGraphPath);
+      AllDependencies.update(entry, entryDepGraph);
       // Sync the entry
       paths.filter(isEntryFiles(entry)).forEach(function(relativePath) {
         syncForwardDependencies(path.join(destDir, relativePath), path.join(srcDir, relativePath));
       }, this);
 
-      return this.selectResolution(srcDir, destDir, this.flattenEntryImports(entry, entryDepGraphPath));
+      return this.selectResolution(srcDir, destDir, this.flattenEntryImports(entry, entryDepGraph));
       
     }, this)).finally(function () {
 
@@ -116,7 +116,7 @@ module.exports = CoreObject.extend({
    */
   selectResolution: function(srcDir, destDir, imports) {
     return mapSeries(uniq(imports), function(imprt) {
-      var importInfo = importType(imprt);
+      var importInfo = getImportInfo(imprt);
 
       if (this.resolutionTypes.indexOf(importInfo.type) < 0) {
         throw new Error('You do not have a resolver for ' + importInfo.type + ' types.');

--- a/lib/resolvers/addon.js
+++ b/lib/resolvers/addon.js
@@ -3,21 +3,18 @@
 var path                    = require('path');
 var AllDependencies         = require('../all-dependencies');
 var syncForwardDependencies = require('../sync-forward-dependencies');
+var getImportInfo           = require('../utils').getImportInfo;
 var fs                      = require('fs-extra');
 
 module.exports = {
-  _getEntry: function(relativePath) {
-    return relativePath.split('/')[0];
-  },
-
   resolve: function(srcDir, destDir, imprt, prePackager) {
-    var entry = this._getEntry(imprt);
-    imprt = entry === imprt ? entry + '/' + imprt + '.js' : imprt + '.js';
+    var pkg = getImportInfo(imprt).pkg;
+    imprt = pkg === imprt ? pkg + '/' + imprt + '.js' : imprt + '.js';
     var dependency = path.join(srcDir, imprt);
     var destination = path.join(destDir, imprt);
-    var depGraph = fs.readJSONSync(path.join(srcDir, entry, 'dep-graph.json'));
+    var depGraph = fs.readJSONSync(path.join(srcDir, pkg, 'dep-graph.json'));
 
-    AllDependencies.update(entry, depGraph);
+    AllDependencies.update(pkg, depGraph);
 
     syncForwardDependencies(destination, dependency);
     return prePackager.selectResolution(srcDir, destDir, AllDependencies.for(imprt), prePackager);

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -10,7 +10,7 @@ var fs         = require('fs-extra');
 var walkSync   = require('walk-sync');
 var mapSeries  = require('promise-map-series');
 
-function _generateStub(moduleName) {
+function generateStub(moduleName) {
   return 'define("npm:' + moduleName + '", function() {' +
          'return { "default": require("' + moduleName + '") };' +
          '});';
@@ -57,7 +57,7 @@ module.exports = {
     return mapSeries(Object.keys(imports), function(pkg) {
       var outFile = path.join(destDir, 'browserified', pkg, pkg + '.js');
       var stub = uniq(imports[pkg]).map(function(file) {
-                  return _generateStub(file);
+                  return generateStub(file);
                 }).join('');
 
       fs.mkdirsSync(path.dirname(outFile));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,7 +25,7 @@ function isEntryFiles(entry) {
   };
 }
 
-function importType(imprt) {
+function getImportInfo(imprt) {
   var importParts = imprt.split(':');
   var type = {};
 
@@ -34,7 +34,7 @@ function importType(imprt) {
     type.id = importParts[1];
     type.pkg = importParts[1].split('/')[0];
   } else {
-    type.type = 'default';
+    type.type = 'addon';
     type.id = imprt;
     type.pkg = imprt.split('/')[0];
   }
@@ -69,6 +69,6 @@ module.exports = {
   flatMap: flatMap,
   flatten: flatten,
   isEntryFiles: isEntryFiles,
-  importType: importType,
+  getImportInfo: getImportInfo,
   arraysEqual: arraysEqual
 };


### PR DESCRIPTION
Since the default resoltion is to resolve addons, it's probably best to remain symantic.  This also includes some minor cleanup.
