### PR TITLE
Ensure we test within the correct CWD

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "broccoli-stew": "^0.2.1",
-    "broccoli-test-helpers": "0.0.6",
+    "broccoli-test-helpers": "0.0.7",
     "chai": "^2.2.0",
     "mocha": "^2.2.1",
     "sinon": "^1.14.1"

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -81,7 +81,6 @@ describe('pre-package acceptance', function () {
 
       return results.builder();
     }).then(function(results) {
-
       // TODO find a better way of restoring this
       fs.outputJSONSync(graphPath, graph);
       fs.writeFileSync(initializer, '');
@@ -137,7 +136,7 @@ describe('pre-package acceptance', function () {
     });
 
     it('should re-browserfify if the package changed', function() {
-      var moment = './node_modules/ember-moment/node_modules/moment/lib/month.js';
+      var moment = './tests/fixtures/example-app/node_modules/ember-moment/node_modules/moment/lib/month.js';
       return prePackager(rename(find('tree'), function(relativePath) {
         return relativePath.replace('tree/', '');
       }), {

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -6,6 +6,17 @@ var fs = require('fs-extra');
 
 describe('all dependencies unit', function() {
   var depGraph;
+  var cwd = process.cwd();
+
+  before(function() {
+    // Note: Normally this is used at the root of
+    // the application that is being built.
+    process.chdir('./tests/fixtures/example-app');
+  });
+
+  after(function() {
+    process.chdir(cwd);
+  });
 
   beforeEach(function () {
     depGraph = fs.readJSONSync('./tree/example-app/dep-graph.json');


### PR DESCRIPTION
This resolves issues where the current working directory would change out from underneath the tests causing the file lookups to sometimes be at the root of the example project and other times in root of ember-cli-pre-packager.  This also pulls in broccoli-test-helpers@0.0.7 to resolve this issue for re-builds.
