### PR TITLE
Cleanup `AllDependencies.for()`

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -6,6 +6,46 @@ var resolvePackage = utils.resolvePackage;
 var path = require('path');
 var resolve = require('resolve').sync;
 
+function node(packageName, imports, pkgInfo) {
+  var parts = process.cwd().split(path.sep);
+  var pkg = parts[parts.length - 1];
+  var parent = pkgInfo.parent;
+
+  if (pkg === packageName) {
+    pkgInfo.pkgPath = process.cwd();
+  } else {
+    pkgInfo.pkgPath = resolvePackage(packageName, parent.pkgPath);
+  }
+
+  pkgInfo.entry = packageName;
+  pkgInfo.imports = imports;
+  return pkgInfo;
+}
+
+function leafNode(pkgInfo) {
+  pkgInfo.pkgPath = process.cwd();
+  pkgInfo.imports = [];
+  pkgInfo.entry = pkgInfo.parent.entry;
+  return pkgInfo;
+}
+
+function foreignNode(packageName, graph, file, pkgInfo) {
+  var entry = pkgInfo.parent.entry;
+  var mainFile = resolve(packageName, { basedir: entry });
+  var index = mainFile.indexOf(file);
+  var isMain = (mainFile.substr(index, mainFile.length).replace('.js', '') === file);
+
+  if (isMain) {
+    pkgInfo.imports = graph[packageName];
+  } else {
+    pkgInfo.imports = graph[file];
+  }
+
+  pkgInfo.entry = entry;
+  pkgInfo.pkgPath = resolvePackage(packageName, entry);
+  return pkgInfo;
+}
+
 
 var AllDependencies = {
   _graph: {},
@@ -39,6 +79,12 @@ var AllDependencies = {
     var infos = getImportInfo(fileOrPackage);
     var packageName = infos.pkg;
     var graph = this._graph[packageName];
+    var pkgInfo = {
+      pkg: packageName,
+      pkgPath: null,
+      parent: parent
+    };
+
     var entry;
 
     if (parent) {
@@ -57,46 +103,12 @@ var AllDependencies = {
     }
 
     if (graph) {
-      var parts = process.cwd().split(path.sep);
-      var pkg = parts[parts.length - 1];
-      var importInfo = {
-        pkg: packageName,
-        pkgPath: null
-      };
-
       if (graph[fileOrPackage]) {
-        // node with deps
-        if (pkg === packageName) {
-          importInfo.pkgPath = process.cwd();
-        } else {
-          importInfo.pkgPath = resolvePackage(packageName, parent.pkgPath);
-        }
-        importInfo.entry = packageName;
-        importInfo.imports = graph[fileOrPackage];
-        return importInfo;
-
+        return node(packageName, graph[fileOrPackage], pkgInfo);
       } else if (fileOrPackage.indexOf(entry) > -1){
-        // leaf node
-        importInfo.pkgPath = process.cwd();
-        importInfo.imports = [];
-        importInfo.entry = entry;
-        return importInfo;
-
+        return leafNode(pkgInfo);
       } else {
-
-        var mainFile = resolve(packageName, { basedir: entry });
-        var index = mainFile.indexOf(fileOrPackage);
-        var isMain = (mainFile.substr(index, mainFile.length).replace('.js', '') === fileOrPackage);
-
-        if (isMain) {
-          importInfo.imports = graph[packageName];
-        } else {
-          importInfo.imports = graph[fileOrPackage];
-        }
-
-        importInfo.entry = entry;
-        importInfo.pkgPath = resolvePackage(packageName, entry);
-        return importInfo;
+        return foreignNode(packageName, graph, fileOrPackage, pkgInfo);
       }
     }
 

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -90,6 +90,7 @@ describe('all dependencies unit', function() {
           'ember-moment/helpers/duration',
           'ember'
         ],
+        parent: undefined,
         pkgPath: process.cwd()
       });
     });


### PR DESCRIPTION
This refactors `AllDependencies.for()` to be more declaritive so that other people understand what the method is doing when it attempts lookup local and transitive depenedencies.
