### PR TITLE
Use the package.json as SSOT for the name of the application

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -3,15 +3,13 @@
 var utils = require('./utils');
 var getImportInfo = utils.getImportInfo;
 var resolvePackage = utils.resolvePackage;
-var path = require('path');
 var resolve = require('resolve').sync;
 
 function node(packageName, imports, pkgInfo) {
-  var parts = process.cwd().split(path.sep);
-  var pkg = parts[parts.length - 1];
+  var name  = require(process.cwd() + '/package.json').name;
   var parent = pkgInfo.parent;
 
-  if (pkg === packageName) {
+  if (name === packageName) {
     pkgInfo.pkgPath = process.cwd();
   } else {
     pkgInfo.pkgPath = resolvePackage(packageName, parent.pkgPath);
@@ -115,6 +113,5 @@ var AllDependencies = {
     return {};
   }
 };
-
 
 module.exports = AllDependencies;


### PR DESCRIPTION
Before I was relying in on the CWD to get the name of the app. This is clearly not reliable, instead we need to look at the package.json to reliably get the name.
