### PR TITLE
Builds given an array of trees

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -1,50 +1,33 @@
 'use strict';
 
 var utils = require('./utils');
-var getImportInfo = utils.getImportInfo;
-var resolvePackage = utils.resolvePackage;
-var resolve = require('resolve').sync;
+var nodes = require('./nodes');
 var path = require('path');
 var debug = require('debug');
+var node = nodes.node;
+var foreignNode = nodes.foreignNode;
+var leafNode = nodes.leafNode;
+var getImportInfo = utils.getImportInfo;
 
-function node(packageName, imports, pkgInfo) {
-  var name  = require(process.cwd() + '/package.json').name;
-  var parent = pkgInfo.parent;
-
-  if (name === packageName) {
-    pkgInfo.pkgPath = process.cwd();
-  } else {
-    pkgInfo.pkgPath = resolvePackage(packageName, parent.pkgPath);
-  }
-
-  pkgInfo.entry = packageName;
-  pkgInfo.imports = imports;
-  return pkgInfo;
-}
-
-function leafNode(pkgInfo) {
-  pkgInfo.pkgPath = process.cwd();
-  pkgInfo.imports = [];
-  pkgInfo.entry = pkgInfo.parent.entry;
-  return pkgInfo;
-}
-
-function foreignNode(packageName, graph, file, pkgInfo) {
-  var entry = pkgInfo.parent.entry;
-  var mainFile = resolve(packageName, { basedir: entry });
-  var index = mainFile.indexOf(file);
-  var isMain = (mainFile.substr(index, mainFile.length).replace('.js', '') === file);
-
-  if (isMain) {
-    pkgInfo.imports = graph[packageName];
-  } else {
-    pkgInfo.imports = graph[file];
-  }
-
-  pkgInfo.entry = entry;
-  pkgInfo.pkgPath = resolvePackage(packageName, entry);
-  return pkgInfo;
-}
+/**
+ * 'example-app': {
+ *   pkgName: 'example-app',
+ *   inputPath: 'tmp-fslajkklfdsjjfd0-djjdjd/',
+ *   relativePaths: [ 'exampler-app/', 'exampler-app/app.js'],
+ *   graph: {
+ *      'exampler-app/app': {
+ *         'imports': {
+ *           'ember': {
+ *             
+ *           }
+ *         }
+ *      }
+ *   },
+ *   importInfos: {
+ *   
+ *   }
+ * }
+ */
 
 var AllDependencies = {
   _graph: {},
@@ -86,7 +69,7 @@ var AllDependencies = {
     var packageName = infos.pkg;
     var graph = this._graph[packageName];
     var pkgInfo = {
-      pkg: packageName,
+      pkgName: packageName,
       pkgPath: null,
       parent: parent
     };

--- a/lib/nodes/foreign-node.js
+++ b/lib/nodes/foreign-node.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var resolve = require('resolve').sync;
+var resolvePackage = require('../utils').resolvePackage;
+
+function foreignNode(packageName, graph, file, pkgInfo) {
+  var entry = pkgInfo.parent.entry;
+  var mainFile = resolve(packageName, { basedir: entry });
+  var index = mainFile.indexOf(file);
+  var isMain = (mainFile.substr(index, mainFile.length).replace('.js', '') === file);
+
+  if (isMain) {
+    pkgInfo.imports = graph[packageName];
+  } else {
+    pkgInfo.imports = graph[file];
+  }
+
+  pkgInfo.entry = entry;
+  pkgInfo.pkgPath = resolvePackage(packageName, entry);
+  return pkgInfo;
+}
+
+module.exports = foreignNode;

--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -1,0 +1,9 @@
+var node = require('./node');
+var leafNode = require('./leaf-node');
+var foreignNode = require('./foreign-node');
+
+module.exports = {
+  node: node,
+  leafNode: leafNode,
+  foreignNode: foreignNode
+};

--- a/lib/nodes/leaf-node.js
+++ b/lib/nodes/leaf-node.js
@@ -1,0 +1,10 @@
+'use strict';
+
+function leafNode(pkgInfo) {
+  pkgInfo.pkgPath = process.cwd();
+  pkgInfo.imports = [];
+  pkgInfo.entry = pkgInfo.parent.entry;
+  return pkgInfo;
+}
+
+module.exports = leafNode;

--- a/lib/nodes/node.js
+++ b/lib/nodes/node.js
@@ -1,0 +1,21 @@
+'use strict';
+var utils = require('../utils');
+var resolvePackage = utils.resolvePackage;
+
+function node(packageName, imports, pkgInfo) {
+  var name  = require(process.cwd() + '/package.json').name;
+  var parent = pkgInfo.parent;
+
+  if (name === packageName) {
+    pkgInfo.pkgPath = process.cwd();
+  } else {
+    pkgInfo.pkgPath = resolvePackage(packageName, parent.pkgPath);
+  }
+
+  pkgInfo.pkgName = packageName;
+  pkgInfo.entry = packageName;
+  pkgInfo.imports = imports;
+  return pkgInfo;
+}
+
+module.exports = node;

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -3,25 +3,26 @@
 var AllDependencies         = require('./all-dependencies');
 var syncForwardDependencies = require('./sync-forward-dependencies');
 var utils                   = require('./utils');
-var uniq                    = utils.uniq;
-var flatMap                 = utils.flatMap;
-var isEntryFiles            = utils.isEntryFiles;
-var getImportInfo           = utils.getImportInfo;
 var CoreObject              = require('core-object');
 var RSVP                    = require('rsvp');
 var walkSync                = require('walk-sync');
 var path                    = require('path');
-var quickTemp               = require('quick-temp');
 var fs                      = require('fs-extra');
+var generateNodeInfo        = require('./nodes/node');
 var mapSeries               = require('promise-map-series');
+var uniq                    = utils.uniq;
+var flatMap                 = utils.flatMap;
+var isEntryFiles            = utils.isEntryFiles;
+var getImportInfo           = utils.getImportInfo;
 
 module.exports = CoreObject.extend({
-  init: function(inputTree, options) {
+  init: function(inputTrees, options) {
     var defaultResolvers = ['addon', 'npm'];
     this.resolvers = {};
-    this.inputTree = inputTree;
+    this.inputTrees = inputTrees;
     this.options = options || {};
     this.importCache = null;
+    this.description = 'Ember CLI Pre-Packager';
 
     if (!this.options.entries) {
       throw new Error('You must pass an array of entries.');
@@ -40,55 +41,62 @@ module.exports = CoreObject.extend({
     this.entries = options.entries;
   },
 
-  read: function(readTree) {
-    quickTemp.makeOrRemake(this, 'tmpDestDir');
-    return RSVP.Promise.resolve(this.write(readTree, this.tmpDestDir)).then(function() {
-      return this.tmpDestDir;
-    }.bind(this));
+  parsedTrees: {},
+
+  parseTree: function(relativePaths, inputPath) {
+    // TODO We need to handle other files differently
+    var pkgName = relativePaths[0].replace('/', '');
+    this.parsedTrees[pkgName] = {
+      inputPath: inputPath,
+      relativePaths: relativePaths
+    };
   },
 
-  write: function(readTree, destDir) {
-    var self = this;
-    return readTree(this.inputTree).then(function(srcDir) {
-      return self.resolveEntries(srcDir, destDir);
-    });
+  rebuild: function() {
+    this.inputPaths.forEach(function(fullPath) {
+      this.parseTree(walkSync(fullPath), fullPath);
+    }, this);
+
+    return this.resolveEntries();
+  },
+
+  syncForwardEntry: function(entry, relativePaths) {
+    var srcDir = this.parsedTrees[entry].inputPath;
+    relativePaths.filter(isEntryFiles(entry)).forEach(function(relativePath) {
+      var destination = path.join(this.outputPath, relativePath);
+      var source = path.join(srcDir, relativePath);
+      syncForwardDependencies(destination, source);
+    }, this);
   },
 
   /**
-   * Syncs alll of the entries' files and then
+   * Syncs all of the entries' files and then
    * begins the resolution and materialization
    * of the graph.
    * @param  {String} srcDir  The source directory of the files
    * @param  {String} destDir The destination temp directory
    * @return {Promise}
    */
-  resolveEntries: function(srcDir, destDir) {
-    var paths = walkSync(srcDir);
-
+  resolveEntries: function() {
     this.importCache = {};
 
     return RSVP.Promise.all(this.entries.map(function(entry) {
-      var entryDepGraph = fs.readJSONSync(path.join(srcDir, entry, 'dep-graph.json'));
+      var dep = this.parsedTrees[entry];
+      var entryDepGraph = fs.readJSONSync(path.join(dep.inputPath, entry, 'dep-graph.json'));
 
       AllDependencies.update(entry, entryDepGraph);
-      // Sync the entry
-      paths.filter(isEntryFiles(entry)).forEach(function(relativePath) {
-        var destination = path.join(destDir, relativePath);
-        var source = path.join(srcDir, relativePath);
-        syncForwardDependencies(destination, source);
-      }, this);
-
-      return this.selectResolution(srcDir, destDir, this.flattenEntryImports(entry, entryDepGraph));
       
+      this.syncForwardEntry(entry, dep.relativePaths);
+
+      return this.selectResolution(entry, this.generatePkgInfo(entry));
     }, this)).then(function () {
       return RSVP.Promise.all(Object.keys(this.resolvers).map(function(resolver) {
         var resolveLater = this.resolvers[resolver].resolveLater;
         var importCache = this.importCache[resolver];
 
         if (resolveLater && importCache) {
-          return resolveLater.call(this.resolvers[resolver], srcDir, destDir, importCache);
+          return resolveLater.call(this.resolvers[resolver], this.outputPath, importCache);
         }
-
       }, this));
     }.bind(this));
   },
@@ -101,19 +109,37 @@ module.exports = CoreObject.extend({
    * @param  {String} graphPath The path to dep-graph.json
    * @return {Array}            The direct dependencies for the entry
    */
-  flattenEntryImports: function(entry) {
+  generatePkgInfo: function(entry) {
     var pkgInfo = {};
 
     var imports = uniq(flatMap(Object.keys(AllDependencies.for(entry)), function(file) {
       var importInfos = AllDependencies.for(file);
-      pkgInfo.pkgPath = importInfos.pkgPath;
-      pkgInfo.pkg = importInfos.pkg;
       return importInfos.imports;
     }));
 
-    pkgInfo.imports = imports;
-    pkgInfo.entry = entry;
+    generateNodeInfo(entry, imports, pkgInfo);
     return pkgInfo;
+  },
+
+  createImportRelationship: function(childInfo, parentInfo) {
+    var type = this.importCache[childInfo.type];
+    var pkgName = parentInfo.pkgName;
+    var childName = childInfo.name;
+    var importRelationship = {
+      parent: pkgName,
+      imports: [childName],
+      parentPath: parentInfo.pkgPath
+    };
+
+    if (!type) {
+      type = this.importCache[childInfo.type] = {};
+    }
+
+    if (!type[pkgName]) {
+      type[pkgName] = importRelationship;
+    } else if (type[pkgName].imports.indexOf(childName) < 0){
+      type[pkgName].imports.push(childName);
+    }
   },
 
   /**
@@ -123,41 +149,27 @@ module.exports = CoreObject.extend({
    * @param  {Array} imports An array of all the imports
    * @return {Promise}
    */
-  selectResolution: function(srcDir, destDir, pkgInfo) {
-    var pkgPath = pkgInfo.pkgPath;
+  selectResolution: function(entry, pkgInfo) {
     var imports = pkgInfo.imports;
 
     return mapSeries(uniq(imports), function(imprt) {
       var importInfo = getImportInfo(imprt);
+      var type = importInfo.type;
+      var resolve = this.resolvers[type].resolve;
+
       if (this.resolutionTypes.indexOf(importInfo.type) < 0) {
         throw new Error('You do not have a resolver for ' + importInfo.type + ' types.');
       }
 
-      var type = this.importCache[importInfo.type];
+      this.createImportRelationship(importInfo, pkgInfo);
 
-      if (!type) {
-        type = this.importCache[importInfo.type] = {};
-      }
-
-      if (!type[pkgPath]) {
-        type[pkgPath] = [imprt];
-      } else {
-        type[pkgPath].push(imprt);
-      }
-
-      if (this.resolvers[importInfo.type].resolve) {
-        return this.resolvers[importInfo.type].resolve(
-          srcDir, destDir, importInfo.id, this, pkgInfo
-        );
-      } else if (this.resolvers[importInfo.type].resolveLater) { 
-        return destDir;
+      if (resolve) {
+        return resolve(this.outputPath, importInfo, this, pkgInfo);
+      } else if (this.resolvers[type].resolveLater) { 
+        return this.outputPath;
       } else {
         throw new Error('No `resolve` or `resolveLater` method on the dependency resolver.');
       }
     }, this);
-  },
-
-  cleanup: function() {
-    fs.removeSync(this.tmpDestDir);
   }
 });

--- a/lib/resolvers/addon.js
+++ b/lib/resolvers/addon.js
@@ -3,19 +3,18 @@
 var path                    = require('path');
 var AllDependencies         = require('../all-dependencies');
 var syncForwardDependencies = require('../sync-forward-dependencies');
-var getImportInfo           = require('../utils').getImportInfo;
 var fs                      = require('fs-extra');
 
 module.exports = {
-  resolve: function(srcDir, destDir, imprt, prePackager, pkgInfo) {
-    var pkg = getImportInfo(imprt).pkg;
-    imprt = pkg === imprt ? pkg + '/' + imprt : imprt;
+  resolve: function(destDir, imprtInfo, prePackager, pkgInfo) {
+    var imprt = imprtInfo.name;
+    var pkg = imprtInfo.pkg;
+    var srcDir = prePackager.parsedTrees[pkg].inputPath;
     var dependency = path.join(srcDir, imprt);
     var destination = path.join(destDir, imprt);
     var depGraph = fs.readJSONSync(path.join(srcDir, pkg, 'dep-graph.json'));
     AllDependencies.update(pkg, depGraph);
-    syncForwardDependencies(destination, dependency + '.js');
-    return prePackager.selectResolution(srcDir, destDir, AllDependencies.for(imprt, pkgInfo));
-
+    syncForwardDependencies(destination + '.js', dependency + '.js');
+    return prePackager.selectResolution(pkg, AllDependencies.for(imprt, pkgInfo));
   }
 };

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var utils       = require('../utils');
-var uniq        = utils.uniq;
 var arraysEqual = utils.arraysEqual;
 var RSVP        = require('rsvp');
 var browserify  = require('browserify');
@@ -40,7 +39,6 @@ module.exports = {
   cache: {},
 
   bundler: function(entry, basedir) {
-
     var b = browserify({
       basedir: basedir
     });
@@ -66,42 +64,59 @@ module.exports = {
     }.bind(this));
   },
 
-  resolveLater: function(srcDir, destDir, importInfo) {
-    return mapSeries(Object.keys(importInfo), function(parentPath) {
-      var parentPkgName = parentPath.split('/').slice(-1)[0];
-      var outFile = path.join(path.resolve('tmp', 'browserified', parentPkgName), parentPkgName + '-legacy.js');
-      fs.mkdirsSync(path.join(path.dirname(outFile)));
+  syncNodeModules: function(parentPath, nodeModulesPath) {
+    if (!fs.existsSync(nodeModulesPath)) {
+      fs.symlinkSync(path.join(parentPath, 'node_modules'), nodeModulesPath);
+    }
+  },
 
+  updateThroughCache: function(options) {
+    var cache = options.cache;
+    var stub = options.stub;
+    var imports = options.imports;
+    var parentPath = options.parentPath;
+    var outFile = options.outFile;
+    var destDir = options.destDir;
+
+    if (!cache || cache.stub !== stub || !hashesValid(imports, parentPath, cache)) {
+      this.cache[parentPath] = {
+        stub: stub,
+        hashes: hashDeps(imports, parentPath)
+      };
+
+      fs.writeFileSync(outFile, stub);
+
+      return this.updateCache(outFile, parentPath, destDir).then(function() {
+        fs.removeSync(path.join(parentPath, 'browserified'));
+      });
+    }
+
+    fs.writeFileSync(outFile, cache.buffer);
+  },
+
+  resolveLater: function(destDir, importRelationship) {
+    return mapSeries(Object.keys(importRelationship), function(parent) {
+      var rel = importRelationship[parent];
+      var parentPath = rel.parentPath;
+      var imports = rel.imports;
+      var cache = this.cache[parentPath];
+      var outFile = path.join(path.resolve('tmp', 'browserified', parent), parent + '-legacy.js');
       var nodeModulesPath = path.dirname(outFile) + '/node_modules';
-
-      if (!fs.existsSync(nodeModulesPath)) {
-        fs.symlinkSync(path.join(parentPath, 'node_modules'), nodeModulesPath);
-      }
-
-      var imports = importInfo[parentPath];
-      var stub = uniq(imports).map(function(imprt) {
+      var stub = imports.map(function(imprt) {
         return generateStub(imprt.replace('npm:', ''));
       }).join('');
 
-      var cache = this.cache[parentPath];
-
       fs.mkdirsSync(path.dirname(outFile));
 
-      if (!cache || cache.stub !== stub || !hashesValid(imports, parentPath, cache)) {
-
-        this.cache[parentPath] = {
-          stub: stub,
-          hashes: hashDeps(imports, parentPath)
-        };
-
-        fs.writeFileSync(outFile, stub);
-        return this.updateCache(outFile, parentPath, destDir).then(function() {
-          fs.removeSync(path.join(parentPath, 'browserified'));
-        });
-      }
-
-      fs.writeFileSync(outFile, cache.buffer);
-
+      this.syncNodeModules(parentPath, nodeModulesPath);
+      return this.updateThroughCache({
+        cache: cache,
+        stub: stub,
+        imports: imports,
+        parentPath: parentPath,
+        outFile: outFile,
+        destDir: destDir
+      });
     }, this);
   }
 };

--- a/lib/sync-forward-dependencies.js
+++ b/lib/sync-forward-dependencies.js
@@ -5,10 +5,6 @@ var path              = require('path');
 var symlinkOrCopySync = require('symlink-or-copy').sync;
 
 module.exports = function(destination, dependency) {
-  if (destination.indexOf('.js') < 0) {
-    destination = destination + '.js';
-  }
-  
   if (!fs.existsSync(destination)) {
     fs.mkdirsSync(path.dirname(destination));
     symlinkOrCopySync(dependency, destination);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,24 +21,31 @@ function flatMap(arr, fn) {
   return flatten(arr.map(fn));
 }
 
-function isEntryFiles(entry) {
+function isEntryFiles() {
   return function(relativePath) {
-    return relativePath.indexOf(entry) > -1 && relativePath.slice(-1) !== '/' && relativePath.indexOf('dep-graph.json') < 0;
+    return relativePath.slice(-1) !== '/';
   };
 }
 
 function getImportInfo(imprt) {
   var importParts = imprt.split(':');
   var type = {};
+  var pkg;
 
   if (importParts.length > 1) {
     type.type = importParts[0];
-    type.id = importParts[1];
+    type.name = importParts[1];
     type.pkg = importParts[1].split('/')[0];
   } else {
+    pkg = imprt.split('/')[0];
+
+    if (pkg === imprt) {
+      imprt = pkg + '/' + imprt;
+    }
+
     type.type = 'addon';
-    type.id = imprt;
-    type.pkg = imprt.split('/')[0];
+    type.name = imprt;
+    type.pkg = pkg;
   }
 
   return type;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "broccoli-stew": "^0.2.1",
-    "broccoli-test-helpers": "0.0.7",
+    "broccoli-test-helpers": "0.0.8",
     "chai": "^2.2.0",
     "debug": "^2.1.3",
     "mocha": "^2.2.1",

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -82,7 +82,7 @@ describe('all dependencies unit', function() {
       AllDependencies.update('example-app', depGraph);
       var imports = AllDependencies.for('example-app/initializers/ember-moment');
       expect(imports).to.deep.equal({
-        pkg: 'example-app',
+        pkgName: 'example-app',
         entry: 'example-app',
         imports: [
           'ember-moment/helpers/moment',


### PR DESCRIPTION
This concludes the work to make the pre-packager take an array of trees. This work encompassed a migration to th  rebuild API in broccoli, which allows us to simply pass the array trees in. While this default helps I had to intorduced a parsed tree cache which holds onto the inputPath for each one of the trees passed in.  Prior to this commit there was only one source directory due to a merge prior to entering.

This work also cleans up a lot of the information gathering and centralizes that logic as much as possible.
