### PR TITLE
Introduce Babel for ES coming from node_modules

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -1,12 +1,11 @@
 'use strict';
 
-var utils = require('./utils');
-var nodes = require('./nodes');
-var debug = require('debug');
-var node = nodes.node;
-var leafNode = nodes.leafNode;
+var utils         = require('./utils');
+var nodes         = require('./nodes');
+var debug         = require('debug');
+var node          = nodes.node;
+var leafNode      = nodes.leafNode;
 var getImportInfo = utils.getImportInfo;
-var arraysEqual = utils.arraysEqual;
 
 function removeExports(imports) {
   var exportsIndex = imports.indexOf('exports');

--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -1,4 +1,4 @@
-var node = require('./node');
+var node     = require('./node');
 var leafNode = require('./leaf-node');
 
 module.exports = {

--- a/lib/nodes/node.js
+++ b/lib/nodes/node.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var utils = require('../utils');
+var utils          = require('../utils');
 var resolvePackage = utils.resolvePackage;
-var path = require('path');
+var path           = require('path');
 
 function node(packageName, imports, pkgInfo, mergedWith) {
   var name = require(process.cwd() + '/package.json').name;

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -7,6 +7,7 @@ var fs              = require('fs-extra');
 var path            = require('path');
 var esperanto       = require('esperanto');
 var helpers         = require('broccoli-kitchen-sink-helpers');
+var babel           = require('babel-core');
 var hashStrings     = helpers.hashStrings;
 
 
@@ -16,10 +17,17 @@ module.exports = {
 
   compileThroughCache: function(source, importName) {
     var mod;
-    var cache = this.cache[importName]
+    var cache = this.cache[importName];
 
     if (!cache || cache.src !== source || hashStrings([source]) !== cache.hash) {
-      mod = esperanto.toAmd(source, {
+
+      var transpiled = babel.transform(source, {
+        blacklist: ['es6.modules', 'useStrict'],
+        nonStandard: false,
+        highlightCode: false
+      }).code;
+
+      mod = esperanto.toAmd(transpiled, {
         amdName: importName,
         absolutePaths: true,
         strict: true

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Chad Hietala, Stefan Penner, and Ember CLI contributors",
   "license": "MIT",
   "dependencies": {
+    "babel-core": "^5.3.3",
     "broccoli-kitchen-sink-helpers": "^0.2.6",
     "browserify": "^9.0.3",
     "core-object": "^1.1.0",

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -126,8 +126,14 @@ describe('pre-package acceptance', function () {
     });
   });
 
-  it('should depupe out dependency of dependency', function() {
-
+  it('should transpile regular es6 modules', function() {
+    return prePackager(generateTrees(), {
+      entries: ['example-app']
+    }).then(function(results) {
+      var babelified = fs.readFileSync(results.directory + '/lodash/lib/array/uniq.js', 'utf8');
+      expect(babelified.indexOf('=>')).to.be.lt(0);
+      expect(babelified.indexOf('...args')).to.be.lt(0);
+    });
   });
   
   // TODO

--- a/tests/fixtures/example-app/node_modules/ember/node_modules/lodash/lib/array/uniq.js
+++ b/tests/fixtures/example-app/node_modules/ember/node_modules/lodash/lib/array/uniq.js
@@ -1,5 +1,7 @@
 import flatten from 'lodash/lib/array/flatten';
 
-export default function uniq() {
-  flatten()
+export default function uniq(...args) {
+  return () => {
+    return flatten(args);
+  };
 }

--- a/tests/unit/nodes-test.js
+++ b/tests/unit/nodes-test.js
@@ -18,7 +18,6 @@ describe('nodes', function() {
   describe('node', function() {
     it('should produce meta info for the app', function() {
       var nodeInfo = nodes.node('example-app', ['ember', 'jQuery'], {});
-      console.log(process.cwd())
       expect(nodeInfo).to.deep.eql({
         pkgPath: process.cwd(),
         pkgName: 'example-app',


### PR DESCRIPTION
As a precaution we must babelify ES code coming from node_modules as they me be using other features besides modules
