### PR TITLE
Don't use require for lookign up package.json and throw error early f…

### DIFF
--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -195,11 +195,13 @@ module.exports = CoreObject.extend({
       var packageName = this._getPackageName(importee, importer);
       var importInfo = getImportInfo(this.treeDescriptors, packageName, importee, importer);
       var type = importInfo.type;
-      var resolve = this.resolvers[type].resolve;
+      var resolve;
 
       if (this.resolutionTypes.indexOf(type) < 0) {
         throw new Error('You do not have a resolver for ' + importInfo.type + ' types.');
       }
+
+      resolve = this.resolvers[type].resolve;
 
       this.cacheImport(importInfo, importer);
 

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -69,7 +69,7 @@ module.exports = {
 
   resolveImport: function(destination, nodeModulesPath, packageName, importName) {
     var root = path.join(nodeModulesPath, packageName);
-    var pkg = require(path.join(root, 'package.json'));
+    var pkg = fs.readJSONSync(path.join(root, 'package.json'));
     var importNodeModulesPath = path.join(root, 'node_modules');
     var descriptor = new Descriptor({
       root: root,


### PR DESCRIPTION
…or failure to find resolver type

Prior to this commit we used require('package.json') to look up the package.json. This caches the result and we do not want that that.

This commit also provides an earlier catch for a resolver type that cannot be resolved.
