### PR TITLE
Introduce idempotent rebuilds and sub-graph resolution

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -65,16 +65,15 @@ var AllDependencies = {
 
   _removalIntersection: function(filesToRemove) {
     var packages = Object.keys(this._graph);
-    var self = this;
 
     return flatten(packages.map(function(packageName) {
-      var packageImports = self._graph[packageName].imports;
+      var packageImports = this._graph[packageName].imports;
       var allImports = flatten(Object.keys(packageImports).map(function(importName) {
         return packageImports[importName];
       }));
 
       return intersect(allImports, filesToRemove);
-    }));
+    }, this));
   },
 
   _removeImportsFromSynced: function(removedFileImports) {
@@ -108,7 +107,7 @@ var AllDependencies = {
   _diffSynced: function(packageName, currentImportHash, newImportHash) {
     var currentFiles = Object.keys(currentImportHash).sort();
     var newFiles = Object.keys(newImportHash).sort();
-    var fileRemoved = currentFiles.length !== newFiles.length;
+    var fileRemoved = currentFiles.length > newFiles.length;
     var removedFileImports = [];
     var importsRemoved;
     var newImports;

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -14,6 +14,24 @@ function removeExports(imports) {
 var AllDependencies = {
   _graph: {},
 
+  _synced: {},
+
+  synced: function(packageName, dependency) {
+    if (!this._synced[packageName]) {
+      this._synced[packageName] = [dependency];
+    } else if (this._synced[packageName].indexOf(dependency) < 0) {
+      this._synced[packageName].push(dependency);
+    }
+  },
+
+  getSynced: function(packageName) {
+    if (packageName) {
+      return this._synced[packageName];
+    }
+
+    return this._synced;
+  },
+
   add: function(descriptor, importName, graph) {
     var name = descriptor.name;
     var imports = removeExports(graph.imports);

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -83,7 +83,7 @@ var AllDependencies = {
       var filesToRemove;
 
       if (removalIntersection.length > 1 ) {
-        filesToRemove = diff(removedFileImports, removalIntersection);
+        filesToRemove = without(removedFileImports, removalIntersection);
       } else {
         filesToRemove = removedFileImports;
       }
@@ -119,7 +119,7 @@ var AllDependencies = {
     }));
 
     if (fileRemoved) {
-      var removedFile = head(diff(currentFiles, newFiles));
+      var removedFile = head(without(currentFiles, newFiles));
       removedFileImports = currentImportHash[removedFile];
       this._removeImportsFromSynced(removedFileImports);
       return;
@@ -129,7 +129,7 @@ var AllDependencies = {
       currentImports = currentImportHash[fileWithRemovals];
       newImports = newImportHash[fileWithRemovals];
       importsRemoved = (currentImports.length > newImports.length);
-      removedFileImports = diff(currentImports, newImports);
+      removedFileImports = without(currentImports, newImports);
       this._removeImportsFromSynced(removedFileImports);
       return;
     }

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -5,12 +5,6 @@ var Descriptor    = require('./models/descriptor');
 var array         = require('./utils/array');
 var uniq          = array.uniq;
 
-function removeExports(imports) {
-  return imports.filter(function(imprt) {
-    return imprt !== 'exports';
-  });
-}
-
 var AllDependencies = {
   _graph: {},
 
@@ -32,9 +26,13 @@ var AllDependencies = {
     return this._synced;
   },
 
+  isSynced: function(packageName, fileName) {
+    return this._synced[packageName] && this._synced[packageName].indexOf(fileName) > -1;
+  },
+
   add: function(descriptor, importName, graph) {
     var name = descriptor.name;
-    var imports = removeExports(graph.imports);
+    var imports = Dependency.removeExports(graph.imports);
     var dependency;
 
     if (!this._graph[name]) {
@@ -51,6 +49,15 @@ var AllDependencies = {
     dependency.addToImports(importName, imports);
   },
 
+  updateExisting: function(packageName, dependencies) {
+    var dependency = this._graph[packageName];
+    if (dependency) {
+      dependency.updateDepenencies(dependencies);
+    } else {
+      throw new Error('Attempted to update ' + packageName + ' that has never been resolved.');
+    }
+  },
+
   update: function(descriptor, dependencies) {
     if (arguments.length === 1 && typeof arguments[0] !== 'object') {
       throw Error('You must pass a descriptor and a dependency graph.');
@@ -61,24 +68,14 @@ var AllDependencies = {
     }
 
     var name = descriptor.name;
-    var imports = {};
-    var dedupedImports = [];
-
-    // Today last one wins... tomorrow something else.
-    Object.keys(dependencies).forEach(function(file) {
-      var fileName = file.replace(/\.js$/, '');
-      var dependency = dependencies[file];
-      var fileImports = removeExports(dependency.imports);
-
-      dedupedImports = dedupedImports.concat(fileImports);
-      imports[fileName] = fileImports;
-    });
+    var imports = Dependency.flattenImports(dependencies);
+    var dedupedImports = Dependency.dedupeImports(imports);
 
     this._graph[name] = new Dependency({
       descriptor: descriptor,
       graph: dependencies,
       imports: imports,
-      dedupedImports: uniq(dedupedImports)
+      dedupedImports: dedupedImports
     });
   },
 

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -3,7 +3,6 @@
 var Package       = require('./models/package');
 var Descriptor    = require('./models/descriptor');
 var array         = require('./utils/array');
-var diff          = array.diff;
 var without       = array.without;
 var flatten       = array.flatten;
 var intersect     = array.intersect;
@@ -133,9 +132,6 @@ var AllDependencies = {
       this._removeImportsFromSynced(removedFileImports);
       return;
     }
-
-    this._synced[packageName].imports = newImportHash;
-
   },
 
   updateExisting: function(packageName, dependencies) {

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -3,18 +3,34 @@
 var Dependency    = require('./models/dependency');
 var Descriptor    = require('./models/descriptor');
 var array         = require('./utils/array');
+var diff          = array.diff;
+var without       = array.without;
 var uniq          = array.uniq;
+var flatten       = array.flatten;
+var intersect     = array.intersect;
+var equal         = array.equal;
+var head          = array.head;
+
+function clone(obj) {
+  var ret = {};
+
+  Object.keys(obj).forEach(function(item)  {
+    ret[item] = obj[item];
+  });
+
+  return ret;
+}
 
 var AllDependencies = {
   _graph: {},
 
   _synced: {},
 
-  synced: function(packageName, dependency) {
+  synced: function(packageName, importName) {
     if (!this._synced[packageName]) {
-      this._synced[packageName] = [dependency];
-    } else if (this._synced[packageName].indexOf(dependency) < 0) {
-      this._synced[packageName].push(dependency);
+      this._synced[packageName] = [importName];
+    } else if (this._synced[packageName].indexOf(importName) < 0) {
+      this._synced[packageName].push(importName);
     }
   },
 
@@ -49,10 +65,91 @@ var AllDependencies = {
     dependency.addToImports(importName, imports);
   },
 
+  _removalIntersection: function(filesToRemove) {
+    var packages = Object.keys(this._graph);
+    var self = this;
+
+    return flatten(packages.map(function(packageName) {
+      var packageImports = self._graph[packageName].imports;
+      var allImports = flatten(Object.keys(packageImports).map(function(importName) {
+        return packageImports[importName];
+      }));
+
+      return intersect(allImports, filesToRemove);
+    }));
+  },
+
+  _removeImportsFromSynced: function(removedFileImports) {
+      var removalIntersection = this._removalIntersection(removedFileImports);
+      var filesToRemove;
+
+      if (removalIntersection.length > 1 ) {
+        filesToRemove = diff(removedFileImports, removalIntersection);
+      } else {
+        filesToRemove = removedFileImports;
+      }
+
+      var packageNames = filesToRemove.map(function(file) {
+        return file.split('/').shift();
+      });
+
+      filesToRemove = filesToRemove.map(function(file) {
+        return file + '.js';
+      });
+
+      packageNames.forEach(function(packageName) {
+        this._synced[packageName] = without(this._synced[packageName], filesToRemove);
+
+        if (this._synced[packageName].length === 0) {
+          delete this._synced[packageName];
+        }
+
+      }, this);
+  },
+
+  _diffSynced: function(packageName, currentImportHash, newImportHash) {
+    var currentFiles = Object.keys(currentImportHash).sort();
+    var newFiles = Object.keys(newImportHash).sort();
+    var fileRemoved = currentFiles.length !== newFiles.length;
+    var removedFileImports = [];
+    var importsRemoved;
+    var newImports;
+    var currentImports;
+    var fileWithRemovals = head(currentFiles.filter(function(file) {
+      return !equal(currentImportHash[file], newImportHash[file]);
+    }));
+
+    if (fileRemoved) {
+      var removedFile = head(diff(currentFiles, newFiles));
+      removedFileImports = currentImportHash[removedFile];
+      this._removeImportsFromSynced(removedFileImports);
+      return;
+    }
+
+    if (fileWithRemovals) {
+      currentImports = currentImportHash[fileWithRemovals];
+      newImports = newImportHash[fileWithRemovals];
+      importsRemoved = (currentImports.length > newImports.length);
+      removedFileImports = diff(currentImports, newImports);
+      this._removeImportsFromSynced(removedFileImports);
+      return;
+    }
+
+    this._synced[packageName].imports = newImportHash;
+
+  },
+
   updateExisting: function(packageName, dependencies) {
     var dependency = this._graph[packageName];
+
     if (dependency) {
-      dependency.updateDepenencies(dependencies);
+      var currentImportsHash = clone(dependency.imports);
+      var newImportHash;
+      dependency.updateDependencies(dependencies);
+      newImportHash = clone(dependency.imports);
+
+      this._diffSynced(packageName, currentImportsHash, newImportHash);
+
     } else {
       throw new Error('Attempted to update ' + packageName + ' that has never been resolved.');
     }
@@ -63,7 +160,7 @@ var AllDependencies = {
       throw Error('You must pass a descriptor and a dependency graph.');
     }
 
-    if (!descriptor instanceof Descriptor) {
+    if (!(descriptor instanceof Descriptor)) {
       descriptor = new Descriptor(descriptor);
     }
 

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -1,11 +1,10 @@
 'use strict';
 
-var Dependency    = require('./models/dependency');
+var Package       = require('./models/package');
 var Descriptor    = require('./models/descriptor');
 var array         = require('./utils/array');
 var diff          = array.diff;
 var without       = array.without;
-var uniq          = array.uniq;
 var flatten       = array.flatten;
 var intersect     = array.intersect;
 var equal         = array.equal;
@@ -48,21 +47,21 @@ var AllDependencies = {
 
   add: function(descriptor, importName, graph) {
     var name = descriptor.packageName;
-    var imports = Dependency.removeExports(graph.imports);
-    var dependency;
+    var imports = Package.removeExports(graph.imports);
+    var pack;
 
     if (!this._graph[name]) {
-      dependency = this._graph[name] = new Dependency({
+      pack = this._graph[name] = new Package({
         descriptor: descriptor,
         dedupedImports: imports
       });
     } else {
-      dependency = this._graph[name];
-      dependency.addToDedupedImports(imports);
+      pack = this._graph[name];
+      pack.addToDedupedImports(imports);
     }
 
-    dependency.addToGraph(importName, graph);
-    dependency.addToImports(importName, imports);
+    pack.addToGraph(importName, graph);
+    pack.addToImports(importName, imports);
   },
 
   _removalIntersection: function(filesToRemove) {
@@ -140,13 +139,13 @@ var AllDependencies = {
   },
 
   updateExisting: function(packageName, dependencies) {
-    var dependency = this._graph[packageName];
+    var pack = this._graph[packageName];
 
-    if (dependency) {
-      var currentImportsHash = clone(dependency.imports);
+    if (pack) {
+      var currentImportsHash = clone(pack.imports);
       var newImportHash;
-      dependency.updateDependencies(dependencies);
-      newImportHash = clone(dependency.imports);
+      pack.updateDependencies(dependencies);
+      newImportHash = clone(pack.imports);
 
       this._diffSynced(packageName, currentImportsHash, newImportHash);
 
@@ -170,10 +169,10 @@ var AllDependencies = {
       descriptor = new Descriptor(descriptor);
     }
 
-    var imports = Dependency.flattenImports(dependencies);
-    var dedupedImports = Dependency.dedupeImports(imports);
+    var imports = Package.flattenImports(dependencies);
+    var dedupedImports = Package.dedupeImports(imports);
 
-    this._graph[name] = new Dependency({
+    this._graph[name] = new Package({
       descriptor: descriptor,
       graph: dependencies,
       imports: imports,

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -47,7 +47,7 @@ var AllDependencies = {
   },
 
   add: function(descriptor, importName, graph) {
-    var name = descriptor.name;
+    var name = descriptor.packageName;
     var imports = Dependency.removeExports(graph.imports);
     var dependency;
 
@@ -159,7 +159,7 @@ var AllDependencies = {
     if (arguments.length === 1 && typeof arguments[0] !== 'object') {
       throw Error('You must pass a descriptor and a dependency graph.');
     }
-    var name = descriptor.name;
+    var name = descriptor.packageName;
 
     if (this._graph[name]) {
       this.updateExisting(name, dependencies);

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -113,7 +113,7 @@ var AllDependencies = {
     var importsRemoved;
     var newImports;
     var currentImports;
-    var fileWithRemovals = head(currentFiles.filter(function(file) {
+    var fileWithUnstableImports = head(currentFiles.filter(function(file) {
       return !equal(currentImportHash[file], newImportHash[file]);
     }));
 
@@ -121,20 +121,28 @@ var AllDependencies = {
       var removedFile = head(without(currentFiles, newFiles));
       removedFileImports = currentImportHash[removedFile];
       this._removeImportsFromSynced(removedFileImports);
-      return;
     }
 
-    if (fileWithRemovals) {
-      currentImports = currentImportHash[fileWithRemovals];
-      newImports = newImportHash[fileWithRemovals];
+    if (fileWithUnstableImports) {
+      currentImports = currentImportHash[fileWithUnstableImports];
+      newImports = newImportHash[fileWithUnstableImports];
       importsRemoved = (currentImports.length > newImports.length);
-      removedFileImports = without(currentImports, newImports);
-      this._removeImportsFromSynced(removedFileImports);
-      return;
+
+      if (importsRemoved) {
+        removedFileImports = without(currentImports, newImports);
+        this._removeImportsFromSynced(removedFileImports);
+      } else {
+        // Note:
+        // Imports are being added. We do not need to
+        // do anything as the hashed graph will cause the subset
+        // of the graph to be resolved. This will cause `syncForwardDependencies`
+        // to place the new items into the graph because it calls `AllDependencies.synced()`
+        // with the new imports as they are resolved.
+      }
     }
   },
 
-  updateExisting: function(packageName, dependencies) {
+  _updateExisting: function(packageName, dependencies) {
     var pack = this._graph[packageName];
 
     if (pack) {
@@ -157,7 +165,7 @@ var AllDependencies = {
     var name = descriptor.packageName;
 
     if (this._graph[name]) {
-      this.updateExisting(name, dependencies);
+      this._updateExisting(name, dependencies);
       return;
     }
 

--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -159,12 +159,17 @@ var AllDependencies = {
     if (arguments.length === 1 && typeof arguments[0] !== 'object') {
       throw Error('You must pass a descriptor and a dependency graph.');
     }
+    var name = descriptor.name;
+
+    if (this._graph[name]) {
+      this.updateExisting(name, dependencies);
+      return;
+    }
 
     if (!(descriptor instanceof Descriptor)) {
       descriptor = new Descriptor(descriptor);
     }
 
-    var name = descriptor.name;
     var imports = Dependency.flattenImports(dependencies);
     var dedupedImports = Dependency.dedupeImports(imports);
 

--- a/lib/models/dependency.js
+++ b/lib/models/dependency.js
@@ -23,7 +23,7 @@ var Dependency = CoreObject.extend({
   addToImports: function (importee, imports) {
     this.imports[importee] = imports;
   },
-  updateDepenencies: function(graph) {
+  updateDependencies: function(graph) {
     this.imports = Dependency.flattenImports(graph);
     this.dedupedImports = Dependency.dedupeImports(this.imports);
     this.graph = graph;

--- a/lib/models/dependency.js
+++ b/lib/models/dependency.js
@@ -1,9 +1,11 @@
 'use strict';
 
 var CoreObject = require('core-object');
-var uniq = require('../utils/array').uniq;
+var array = require('../utils/array');
+var uniq  = array.uniq;
+var flatten = array.flatten;
 
-module.exports = CoreObject.extend({
+var Dependency = CoreObject.extend({
   init: function(options) {
     options = options || {};
     this.descriptor = options.descriptor || {};
@@ -20,5 +22,36 @@ module.exports = CoreObject.extend({
   },
   addToImports: function (importee, imports) {
     this.imports[importee] = imports;
+  },
+  updateDepenencies: function(graph) {
+    this.imports = Dependency.flattenImports(graph);
+    this.dedupedImports = Dependency.dedupeImports(this.imports);
+    this.graph = graph;
+    this.descriptor.updateRelativePaths();
   }
 });
+
+Dependency.flattenImports = function(dependencies) {
+  var imports = {};
+  Object.keys(dependencies).forEach(function(file) {
+    var fileName = file.replace(/\.js$/, '');
+    var dependency = dependencies[file];
+    var fileImports = Dependency.removeExports(dependency.imports);
+    imports[fileName] = fileImports;
+  });
+  return imports;
+};
+
+Dependency.dedupeImports = function(imports) {
+  return uniq(flatten(Object.keys(imports).map(function(importer) {
+    return uniq(imports[importer]);
+  })));
+};
+
+Dependency.removeExports = function(imports) {
+  return imports.filter(function(imprt) {
+    return imprt !== 'exports';
+  });
+};
+
+module.exports = Dependency;

--- a/lib/models/descriptor.js
+++ b/lib/models/descriptor.js
@@ -11,5 +11,6 @@ module.exports = CoreObject.extend({
     this.relativePaths = options.relativePaths;
     this.parent = options.parent;
     this.name = options.name;
+    this.srcDir = options.srcDir;
   }
 });

--- a/lib/models/descriptor.js
+++ b/lib/models/descriptor.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var CoreObject = require('core-object');
+var walkSync = require('walk-sync');
 
 module.exports = CoreObject.extend({
   init: function(options) {
@@ -12,5 +13,8 @@ module.exports = CoreObject.extend({
     this.parent = options.parent;
     this.name = options.name;
     this.srcDir = options.srcDir;
+  },
+  updateRelativePaths: function() {
+    this.relativePaths = walkSync(this.srcDir);
   }
 });

--- a/lib/models/descriptor.js
+++ b/lib/models/descriptor.js
@@ -5,7 +5,7 @@ var CoreObject = require('core-object');
 module.exports = CoreObject.extend({
   init: function(options) {
     this.root = options.root;
-    this.pkgName = options.pkgName;
+    this.packageName = options.packageName;
     this.nodeModulesPath = options.nodeModulesPath;
     this.pkg = options.pkg;
     this.relativePaths = options.relativePaths;

--- a/lib/models/descriptor.js
+++ b/lib/models/descriptor.js
@@ -11,7 +11,6 @@ module.exports = CoreObject.extend({
     this.pkg = options.pkg;
     this.relativePaths = options.relativePaths;
     this.parent = options.parent;
-    this.name = options.name;
     this.srcDir = options.srcDir;
   },
   updateRelativePaths: function() {

--- a/lib/models/import.js
+++ b/lib/models/import.js
@@ -5,7 +5,7 @@ var CoreObject = require('core-object');
 module.exports = CoreObject.extend({
   init: function(options) {
     this.importer = options.importer;
-    this.pkgName = options.pkgName;
+    this.packageName = options.packageName;
     this.name = options.name;
     this.type = options.type;
   }

--- a/lib/models/package.js
+++ b/lib/models/package.js
@@ -5,7 +5,7 @@ var array = require('../utils/array');
 var uniq  = array.uniq;
 var flatten = array.flatten;
 
-var Dependency = CoreObject.extend({
+var Package = CoreObject.extend({
   init: function(options) {
     options = options || {};
     this.descriptor = options.descriptor || {};
@@ -24,34 +24,34 @@ var Dependency = CoreObject.extend({
     this.imports[importee] = imports;
   },
   updateDependencies: function(graph) {
-    this.imports = Dependency.flattenImports(graph);
-    this.dedupedImports = Dependency.dedupeImports(this.imports);
+    this.imports = Package.flattenImports(graph);
+    this.dedupedImports = Package.dedupeImports(this.imports);
     this.graph = graph;
     this.descriptor.updateRelativePaths();
   }
 });
 
-Dependency.flattenImports = function(dependencies) {
+Package.flattenImports = function(dependencies) {
   var imports = {};
   Object.keys(dependencies).forEach(function(file) {
     var fileName = file.replace(/\.js$/, '');
     var dependency = dependencies[file];
-    var fileImports = Dependency.removeExports(dependency.imports);
+    var fileImports = Package.removeExports(dependency.imports);
     imports[fileName] = fileImports;
   });
   return imports;
 };
 
-Dependency.dedupeImports = function(imports) {
+Package.dedupeImports = function(imports) {
   return uniq(flatten(Object.keys(imports).map(function(importer) {
     return uniq(imports[importer]);
   })));
 };
 
-Dependency.removeExports = function(imports) {
+Package.removeExports = function(imports) {
   return imports.filter(function(imprt) {
     return imprt !== 'exports';
   });
 };
 
-module.exports = Dependency;
+module.exports = Package;

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -242,7 +242,8 @@ module.exports = CoreObject.extend({
   resolve: function(treeNames) {
     return RSVP.Promise.all(treeNames.map(function(treeName) {
       var desc = this.treeDescriptors[treeName];
-      var name = desc.name;
+      var name = desc.packageName;
+      console.log(name); 
       var graphPath = path.join(desc.srcDir, name, 'dep-graph.json');
       var entryDepGraph = fs.readJSONSync(graphPath);
 

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -79,13 +79,19 @@ module.exports = CoreObject.extend({
       var name = treeNameAndPath[0];
       var srcDir = treeNameAndPath[1];
       var depGraphPath = path.join(srcDir, name, 'dep-graph.json');
+      var graph;
 
       if (fs.existsSync(depGraphPath)) {
-        graphHashes[name] = helpers.hashStrings([fs.readFileSync(depGraphPath)]);
+        graph = fs.readFileSync(depGraphPath, 'utf8');
+        graphHashes[name] = { name: name, hash: helpers.hashStrings([graph]), graph: graph };
       }
     });
 
     return graphHashes;
+  },
+
+  gatherGraphSubset: function() {
+
   },
 
   _diffGraphs: function() {
@@ -96,10 +102,10 @@ module.exports = CoreObject.extend({
     var diff = [];
 
     var unstable = existing.filter(function(name) {
-      var item = existingHashes[name];
-      return incomingHashes[name] !== item;
+      var hash = existingHashes[name].hash;
+      return incomingHashes[name].hash !== hash;
     }, this).map(function(name) {
-      return name;
+      return incomingHashes[name];
     });
 
     if (unstable.length === 0) {
@@ -117,16 +123,25 @@ module.exports = CoreObject.extend({
 
   diffGraph: function() {
     var graphHashes = Object.keys(this.graphHashes);
-    var diff;
+    var diffs;
 
     if (graphHashes.length === 0) {
       this.graphHashes = this.hashGraphs();
       return Object.keys(this.graphHashes);
     } else {
-      diff = this._diffGraphs();
+      diffs = this._diffGraphs();
 
-      if (diff.length > 0) {
-        return diff;
+      if (diffs.length > 0) {
+        var treesToReValidate = diffs.map(function(diff) {
+          var packageName = diff.name;
+          var dependencies = diff.graph;
+          AllDependencies.updateExisting(packageName, dependencies);
+          return packageName;
+        });
+
+        console.log(treesToReValidate);
+
+        return treesToReValidate;
       } else {
         return [];
       }
@@ -154,7 +169,7 @@ module.exports = CoreObject.extend({
     var diff = this.diffGraph();
 
     if (diff.length > 0) {
-      return this.resolveEntries();
+      return this.resolve(diff);
     } else {
       return this.syncForwardAll();
     }
@@ -174,7 +189,7 @@ module.exports = CoreObject.extend({
     var self = this;
     // TODO
     // Having this here sucks because are now bleeding details about
-    // the input to the pre-packager.
+    // the input to the pre-packager. Consider using a whitelist.
     var whitelist = ['__packager__', 'loader.js', 'ember-cli-shims'];
     zip(this.inputTrees, this.inputPaths).filter(function(treeAndPath) {
       var tree = treeAndPath[0];
@@ -215,10 +230,10 @@ module.exports = CoreObject.extend({
    * @param  {String} destDir The destination temp directory
    * @return {Promise}
    */
-  resolveEntries: function() {
+  resolve: function(treeNames) {
     this.importCache = {};
 
-    return RSVP.Promise.all(this.entries.map(function(entry) {
+    return RSVP.Promise.all(treeNames.map(function(entry) {
       var desc = this.treeDescriptors[entry];
       var name = desc.name;
       var graphPath = path.join(desc.srcDir, name, 'dep-graph.json');
@@ -289,7 +304,12 @@ module.exports = CoreObject.extend({
       var packageName = this._getPackageName(importee, importer);
       var importInfo = getImportInfo(this.treeDescriptors, packageName, importee, importer);
       var type = importInfo.type;
+<<<<<<< HEAD
       var resolve;
+=======
+      var resolve = this.resolvers[type].resolve;
+      var isSynced = AllDependencies.isSynced(importInfo.packageName, importee + '.js');
+>>>>>>> Builds with dependency refactor
 
       if (this.resolutionTypes.indexOf(type) < 0) {
         throw new Error('You do not have a resolver for ' + importInfo.type + ' types.');
@@ -299,7 +319,9 @@ module.exports = CoreObject.extend({
 
       this.cacheImport(importInfo, importer);
 
-      if (resolve) {
+      if (isSynced) {
+        return this.outputPath;
+      } else if (resolve) {
         return resolve.call(this.resolvers[type], this.outputPath, importInfo, this);
       } else if (this.resolvers[type].resolveLater) { 
         return this.outputPath;

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -12,6 +12,7 @@ var mapSeries               = require('promise-map-series');
 var getImportInfo           = require('./utils/get-import-info');
 var helpers                 = require('broccoli-kitchen-sink-helpers');
 var zip                     = array.zip;
+var uniq                    = array.uniq;
 
 module.exports = CoreObject.extend({
   init: function(inputTrees, options) {
@@ -68,26 +69,98 @@ module.exports = CoreObject.extend({
       var depGraphPath = path.join(srcDir, name, 'dep-graph.json');
       treeDescriptor.srcDir = srcDir;
       treeDescriptor.relativePaths = walkSync(srcDir);
-      if (fs.existsSync(depGraphPath)) {
-        this.graphHashes[name] = helpers.hashStrings([fs.readFileSync(depGraphPath)]);
-      }
     }, this);
   },
 
-  hashTrees: function() {
+  hashGraphs: function() {
+    var graphHashes = {};
+
     this._eligibleTrees().forEach(function(treeNameAndPath) {
       var name = treeNameAndPath[0];
       var srcDir = treeNameAndPath[1];
-      this.trees[name] = helpers.hashTree(srcDir);
-    }, this);
+      var depGraphPath = path.join(srcDir, name, 'dep-graph.json');
+
+      if (fs.existsSync(depGraphPath)) {
+        graphHashes[name] = helpers.hashStrings([fs.readFileSync(depGraphPath)]);
+      }
+    });
+
+    return graphHashes;
+  },
+
+  _diffGraphs: function() {
+    var existingHashes = this.graphHashes;
+    var existing = Object.keys(this.graphHashes);
+    var incomingHashes = this.hashGraphs();
+    var incoming = Object.keys(incomingHashes);
+    var diff = [];
+
+    var unstable = existing.filter(function(name) {
+      var item = existingHashes[name];
+      return incomingHashes[name] !== item;
+    }, this).map(function(name) {
+      return name;
+    });
+
+    console.log('Unstable: ', unstable);
+
+    if (unstable.length === 0) {
+      return unstable;
+    }
+
+    
+
+    var addition = incoming.filter(function(name) {
+      return existing.indexOf(name) < 0;
+    });
+
+    console.log('Addition: ', addition);
+
+    diff = uniq(diff.concat(addition, unstable));
+
+    return diff;
+  },
+
+  diffGraph: function() {
+    var graphHashes = Object.keys(this.graphHashes);
+    var diff;
+
+    if (graphHashes.length === 0) {
+      this.graphHashes = this.hashGraphs();
+      return Object.keys(this.graphHashes);
+    } else {
+      diff = this._diffGraphs();
+
+      if (diff.length > 0) {
+        return diff;
+      } else {
+        return [];
+      }
+    }
+  },
+
+  syncForwardAll: function() {
+    var syncedItems = AllDependencies.getSynced();
+    var outputPath = this.outputPath;
+
+    Object.keys(syncedItems).forEach(function(name) {
+      syncedItems[name].forEach(function(file) {
+        fs.symlinkSync(file, outputPath);
+      });
+    });
   },
 
   rebuild: function() {
     this.decorateTreeDescriptors();
     this.syncForwardNonGraphAssets();
-    this.hashTrees();
-    console.log(AllDependencies.getSynced());
-    return this.resolveEntries();
+    var diff = this.diffGraph();
+
+    if (diff.length > 0) {
+      return this.resolveEntries();
+    } else {
+      return this.syncForwardAll();
+    }
+
   },
 
   _filterOutDiretory: function(relativePath) {

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -10,6 +10,7 @@ var path                    = require('path');
 var fs                      = require('fs-extra');
 var mapSeries               = require('promise-map-series');
 var getImportInfo           = require('./utils/get-import-info');
+var helpers                 = require('broccoli-kitchen-sink-helpers');
 var zip                     = array.zip;
 
 module.exports = CoreObject.extend({
@@ -21,6 +22,8 @@ module.exports = CoreObject.extend({
     this.options = options || {};
     this.importCache = null;
     this.description = 'Ember CLI Pre-Packager';
+    this.trees = {};
+    this.graphHashes = {};
 
     if (!this.options.entries) {
       throw new Error('You must pass an array of entries.');
@@ -43,27 +46,47 @@ module.exports = CoreObject.extend({
     this.entries = options.entries;
   },
 
-  decorateTreeDescriptors: function() {
-    var treeNames = this.inputTrees.map(function(tree) {
+  _treeNames: function() {
+    return this.inputTrees.map(function(tree) {
       return tree.name;
     });
+  },
 
-    zip(treeNames, this.inputPaths).filter(function(treeNameAndPath) {
+  _eligibleTrees: function() {
+    return zip(this._treeNames(), this.inputPaths).filter(function(treeNameAndPath) {
       var name = treeNameAndPath[0];
       var srcDir = treeNameAndPath[1];
       return name && srcDir;
-    }).forEach(function(treeNameAndPath) {
+    });
+  },
+
+  decorateTreeDescriptors: function() {
+    this._eligibleTrees().forEach(function(treeNameAndPath) {
       var name = treeNameAndPath[0];
       var srcDir = treeNameAndPath[1];
       var treeDescriptor = this.treeDescriptors[name];
+      var depGraphPath = path.join(srcDir, name, 'dep-graph.json');
       treeDescriptor.srcDir = srcDir;
       treeDescriptor.relativePaths = walkSync(srcDir);
+      if (fs.existsSync(depGraphPath)) {
+        this.graphHashes[name] = helpers.hashStrings([fs.readFileSync(depGraphPath)]);
+      }
+    }, this);
+  },
+
+  hashTrees: function() {
+    this._eligibleTrees().forEach(function(treeNameAndPath) {
+      var name = treeNameAndPath[0];
+      var srcDir = treeNameAndPath[1];
+      this.trees[name] = helpers.hashTree(srcDir);
     }, this);
   },
 
   rebuild: function() {
     this.decorateTreeDescriptors();
     this.syncForwardNonGraphAssets();
+    this.hashTrees();
+    console.log(AllDependencies.getSynced());
     return this.resolveEntries();
   },
 
@@ -95,7 +118,7 @@ module.exports = CoreObject.extend({
       relativePaths.filter(self._filterOutDiretory).forEach(function (relativePath) {
         var source = srcDir + '/' + relativePath;
         var destination = self.outputPath + '/' + relativePath;
-        syncForwardDependencies(destination, source);
+        syncForwardDependencies('__non_js_asset__', destination, source);
       });
     });
   },
@@ -109,7 +132,7 @@ module.exports = CoreObject.extend({
       var destination = path.join(this.outputPath, relativePath);
       var source = path.join(srcDir, relativePath);
 
-      syncForwardDependencies(destination, source);
+      syncForwardDependencies(entry, destination, source);
     }, this);
   },
 

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -26,7 +26,6 @@ module.exports = CoreObject.extend({
     this.description = 'Ember CLI Pre-Packager';
     this.trees = {};
     this.graphHashes = {};
-    this.graphResolved = false;
 
     if (!this.options.entries) {
       throw new Error('You must pass an array of entries.');
@@ -168,15 +167,16 @@ module.exports = CoreObject.extend({
   rebuild: function() {
     this.decorateTreeDescriptors();
     this.syncForwardNonGraphAssets();
+    var isRebuild = Object.keys(this.graphHashes).length > 0;
     var diffs = this.diffGraph();
     var stablePackages;
     var allPackages;
 
-    if (!this.graphResolved) {
+    if (!isRebuild) {
       return this.resolve(this.entries);
     } else if (diffs.length > 0) {
       allPackages = Object.keys(AllDependencies.getSynced());
-      stablePackages = without(allPackages, diffs.map(function(diff) { return diff.name }));
+      stablePackages = without(allPackages, diffs.map(function(diff) { return diff.name; }));
       this.syncForwardStablePackages(stablePackages);
       return this.resolve(diffs);
     } else {
@@ -198,7 +198,8 @@ module.exports = CoreObject.extend({
     var self = this;
     // TODO
     // Having this here sucks because are now bleeding details about
-    // the input to the pre-packager. Consider using a whitelist.
+    // the input to the pre-packager. Consider using a whitelist. While this
+    // feels weird it is a path for `app.import` migration path.
     var whitelist = ['__packager__', 'loader.js', 'ember-cli-shims'];
     zip(this.inputTrees, this.inputPaths).filter(function(treeAndPath) {
       var tree = treeAndPath[0];
@@ -260,9 +261,7 @@ module.exports = CoreObject.extend({
         }
 
         return RSVP.Promise.resolve();
-      }, this)).then(function() {
-        this.graphResolved = true;
-      }.bind(this));
+      }, this));
     }.bind(this));
   },
 

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -243,7 +243,6 @@ module.exports = CoreObject.extend({
     return RSVP.Promise.all(treeNames.map(function(treeName) {
       var desc = this.treeDescriptors[treeName];
       var name = desc.packageName;
-      console.log(name); 
       var graphPath = path.join(desc.srcDir, name, 'dep-graph.json');
       var entryDepGraph = fs.readJSONSync(graphPath);
 

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -115,17 +115,20 @@ module.exports = CoreObject.extend({
   diffGraph: function() {
     var graphHashes = this.graphHashes;
     var diffs = [];
+    var fileChanged;
 
     if (Object.keys(graphHashes).length === 0) {
       this.graphHashes = this.hashGraphs();
     } else {
       diffs = this._diffGraphs();
+      fileChanged = diffs.length > 0;
 
-      if (diffs.length > 0) {
+      if (fileChanged) {
         return diffs.map(function(diff) {
           var packageName = diff.name;
           var dependencies = diff.graph;
-          AllDependencies.updateExisting(packageName, dependencies);
+          var descriptor = AllDependencies.for(packageName).descriptor;
+          AllDependencies.update(descriptor, dependencies);
           return packageName;
         });
       }

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -150,20 +150,6 @@ module.exports = CoreObject.extend({
     });
   },
 
-  syncForwardAll: function() {
-    var syncedItems = AllDependencies.getSynced();
-    var outputPath = this.outputPath;
-    Object.keys(syncedItems).forEach(function(name) {
-      var srcBase = AllDependencies.for(name).descriptor.srcDir;
-      syncedItems[name].forEach(function(file) {
-        var srcPath = srcBase + path.sep + file;
-        var destPath = outputPath + path.sep + file;
-        fs.mkdirsSync(path.dirname(destPath));
-        symlinkOrCopySync(srcPath, destPath);
-      });
-    });
-  },
-
   rebuild: function() {
     this.decorateTreeDescriptors();
     this.syncForwardNonGraphAssets();
@@ -180,7 +166,7 @@ module.exports = CoreObject.extend({
       this.syncForwardStablePackages(stablePackages);
       return this.resolve(diffs);
     } else {
-      return this.syncForwardAll();
+      return this.syncForwardStablePackages(Object.keys(this.graphHashes));
     }
 
   },

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -17,6 +17,7 @@ var without                 = array.without;
 
 module.exports = CoreObject.extend({
   init: function(inputTrees, options) {
+    options = options || {};
     var defaultResolvers = ['ember-app', 'npm', 'es'];
     this.resolvers = {};
     this.treeDescriptors = options.treeDescriptors;
@@ -115,8 +116,9 @@ module.exports = CoreObject.extend({
     var graphHashes = this.graphHashes;
     var diffs = [];
     var fileChanged;
+    var isInitialBuild = Object.keys(graphHashes).length === 0;
 
-    if (Object.keys(graphHashes).length === 0) {
+    if (isInitialBuild) {
       this.graphHashes = this.hashGraphs();
     } else {
       diffs = this._diffGraphs();

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -253,17 +253,17 @@ module.exports = CoreObject.extend({
   cacheImport: function(importInfo, importer) {
     if (!this.importCache[importInfo.type]) {
       this.importCache[importInfo.type] = {};
-      this.importCache[importInfo.type][importInfo.pkgName] = {
+      this.importCache[importInfo.type][importInfo.packageName] = {
         imports: [importInfo],
         parent: AllDependencies.for(importer)
       };
-    } else if (!this.importCache[importInfo.type][importInfo.pkgName]) {
-      this.importCache[importInfo.type][importInfo.pkgName] = {
+    } else if (!this.importCache[importInfo.type][importInfo.packageName]) {
+      this.importCache[importInfo.type][importInfo.packageName] = {
         imports: [importInfo],
         parent: AllDependencies.for(importer)
       };
     } else if (!this._containsImport(importInfo)) {
-      this.importCache[importInfo.type][importInfo.pkgName].imports.push(importInfo);
+      this.importCache[importInfo.type][importInfo.packageName].imports.push(importInfo);
     }
   },
 

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -11,6 +11,7 @@ var fs                      = require('fs-extra');
 var mapSeries               = require('promise-map-series');
 var getImportInfo           = require('./utils/get-import-info');
 var helpers                 = require('broccoli-kitchen-sink-helpers');
+var symlinkOrCopySync       = require('symlink-or-copy').sync;
 var zip                     = array.zip;
 var uniq                    = array.uniq;
 
@@ -66,7 +67,6 @@ module.exports = CoreObject.extend({
       var name = treeNameAndPath[0];
       var srcDir = treeNameAndPath[1];
       var treeDescriptor = this.treeDescriptors[name];
-      var depGraphPath = path.join(srcDir, name, 'dep-graph.json');
       treeDescriptor.srcDir = srcDir;
       treeDescriptor.relativePaths = walkSync(srcDir);
     }, this);
@@ -102,19 +102,13 @@ module.exports = CoreObject.extend({
       return name;
     });
 
-    console.log('Unstable: ', unstable);
-
     if (unstable.length === 0) {
       return unstable;
     }
 
-    
-
     var addition = incoming.filter(function(name) {
       return existing.indexOf(name) < 0;
     });
-
-    console.log('Addition: ', addition);
 
     diff = uniq(diff.concat(addition, unstable));
 
@@ -144,8 +138,12 @@ module.exports = CoreObject.extend({
     var outputPath = this.outputPath;
 
     Object.keys(syncedItems).forEach(function(name) {
+      var srcBase = AllDependencies.for(name).descriptor.srcDir;
       syncedItems[name].forEach(function(file) {
-        fs.symlinkSync(file, outputPath);
+        var srcPath = srcBase + path.sep + file;
+        var destPath = outputPath + path.sep + file;
+        fs.mkdirsSync(path.dirname(destPath));
+        symlinkOrCopySync(srcPath, destPath);
       });
     });
   },
@@ -191,7 +189,7 @@ module.exports = CoreObject.extend({
       relativePaths.filter(self._filterOutDiretory).forEach(function (relativePath) {
         var source = srcDir + '/' + relativePath;
         var destination = self.outputPath + '/' + relativePath;
-        syncForwardDependencies('__non_js_asset__', destination, source);
+        syncForwardDependencies('__non_js_asset__', destination, source, relativePath, true);
       });
     });
   },
@@ -205,7 +203,7 @@ module.exports = CoreObject.extend({
       var destination = path.join(this.outputPath, relativePath);
       var source = path.join(srcDir, relativePath);
 
-      syncForwardDependencies(entry, destination, source);
+      syncForwardDependencies(entry, destination, source, relativePath);
     }, this);
   },
 

--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -13,7 +13,7 @@ var getImportInfo           = require('./utils/get-import-info');
 var helpers                 = require('broccoli-kitchen-sink-helpers');
 var symlinkOrCopySync       = require('symlink-or-copy').sync;
 var zip                     = array.zip;
-var uniq                    = array.uniq;
+var without                 = array.without;
 
 module.exports = CoreObject.extend({
   init: function(inputTrees, options) {
@@ -22,10 +22,11 @@ module.exports = CoreObject.extend({
     this.treeDescriptors = options.treeDescriptors;
     this.inputTrees = inputTrees;
     this.options = options || {};
-    this.importCache = null;
+    this.importCache = {};
     this.description = 'Ember CLI Pre-Packager';
     this.trees = {};
     this.graphHashes = {};
+    this.graphResolved = false;
 
     if (!this.options.entries) {
       throw new Error('You must pass an array of entries.');
@@ -82,24 +83,18 @@ module.exports = CoreObject.extend({
       var graph;
 
       if (fs.existsSync(depGraphPath)) {
-        graph = fs.readFileSync(depGraphPath, 'utf8');
-        graphHashes[name] = { name: name, hash: helpers.hashStrings([graph]), graph: graph };
+        graph = fs.readJSONSync(depGraphPath, 'utf8');
+        graphHashes[name] = { name: name, hash: helpers.hashStrings([JSON.stringify(graph)]), graph: graph };
       }
     });
 
     return graphHashes;
   },
 
-  gatherGraphSubset: function() {
-
-  },
-
   _diffGraphs: function() {
     var existingHashes = this.graphHashes;
     var existing = Object.keys(this.graphHashes);
     var incomingHashes = this.hashGraphs();
-    var incoming = Object.keys(incomingHashes);
-    var diff = [];
 
     var unstable = existing.filter(function(name) {
       var hash = existingHashes[name].hash;
@@ -108,50 +103,54 @@ module.exports = CoreObject.extend({
       return incomingHashes[name];
     });
 
-    if (unstable.length === 0) {
-      return unstable;
+    if (unstable.length > 0) {
+      unstable.forEach(function(hash) {
+        this.graphHashes[hash.name] = hash;
+      }, this);
     }
-
-    var addition = incoming.filter(function(name) {
-      return existing.indexOf(name) < 0;
-    });
-
-    diff = uniq(diff.concat(addition, unstable));
-
-    return diff;
+    
+    return unstable;
   },
 
   diffGraph: function() {
-    var graphHashes = Object.keys(this.graphHashes);
-    var diffs;
+    var graphHashes = this.graphHashes;
+    var diffs = [];
 
-    if (graphHashes.length === 0) {
+    if (Object.keys(graphHashes).length === 0) {
       this.graphHashes = this.hashGraphs();
-      return Object.keys(this.graphHashes);
     } else {
       diffs = this._diffGraphs();
 
       if (diffs.length > 0) {
-        var treesToReValidate = diffs.map(function(diff) {
+        return diffs.map(function(diff) {
           var packageName = diff.name;
           var dependencies = diff.graph;
           AllDependencies.updateExisting(packageName, dependencies);
           return packageName;
         });
-
-        console.log(treesToReValidate);
-
-        return treesToReValidate;
-      } else {
-        return [];
       }
     }
+
+    return diffs;
+  },
+
+  syncForwardStablePackages: function(stablePackages) {
+    var syncedItems = AllDependencies.getSynced();
+    var outputPath = this.outputPath;
+    stablePackages.forEach(function(name) {
+      var srcBase = AllDependencies.for(name).descriptor.srcDir;
+      syncedItems[name].forEach(function(file) {
+        var srcPath = srcBase + path.sep + file;
+        var destPath = outputPath + path.sep + file;
+        fs.mkdirsSync(path.dirname(destPath));
+        symlinkOrCopySync(srcPath, destPath);
+      });
+    });
   },
 
   syncForwardAll: function() {
     var syncedItems = AllDependencies.getSynced();
     var outputPath = this.outputPath;
-
     Object.keys(syncedItems).forEach(function(name) {
       var srcBase = AllDependencies.for(name).descriptor.srcDir;
       syncedItems[name].forEach(function(file) {
@@ -166,10 +165,17 @@ module.exports = CoreObject.extend({
   rebuild: function() {
     this.decorateTreeDescriptors();
     this.syncForwardNonGraphAssets();
-    var diff = this.diffGraph();
+    var diffs = this.diffGraph();
+    var stablePackages;
+    var allPackages;
 
-    if (diff.length > 0) {
-      return this.resolve(diff);
+    if (!this.graphResolved) {
+      return this.resolve(this.entries);
+    } else if (diffs.length > 0) {
+      allPackages = Object.keys(AllDependencies.getSynced());
+      stablePackages = without(allPackages, diffs.map(function(diff) { return diff.name }));
+      this.syncForwardStablePackages(stablePackages);
+      return this.resolve(diffs);
     } else {
       return this.syncForwardAll();
     }
@@ -231,10 +237,8 @@ module.exports = CoreObject.extend({
    * @return {Promise}
    */
   resolve: function(treeNames) {
-    this.importCache = {};
-
-    return RSVP.Promise.all(treeNames.map(function(entry) {
-      var desc = this.treeDescriptors[entry];
+    return RSVP.Promise.all(treeNames.map(function(treeName) {
+      var desc = this.treeDescriptors[treeName];
       var name = desc.name;
       var graphPath = path.join(desc.srcDir, name, 'dep-graph.json');
       var entryDepGraph = fs.readJSONSync(graphPath);
@@ -253,7 +257,9 @@ module.exports = CoreObject.extend({
         }
 
         return RSVP.Promise.resolve();
-      }, this));
+      }, this)).then(function() {
+        this.graphResolved = true;
+      }.bind(this));
     }.bind(this));
   },
 
@@ -304,13 +310,8 @@ module.exports = CoreObject.extend({
       var packageName = this._getPackageName(importee, importer);
       var importInfo = getImportInfo(this.treeDescriptors, packageName, importee, importer);
       var type = importInfo.type;
-<<<<<<< HEAD
-      var resolve;
-=======
       var resolve = this.resolvers[type].resolve;
       var isSynced = AllDependencies.isSynced(importInfo.packageName, importee + '.js');
->>>>>>> Builds with dependency refactor
-
       if (this.resolutionTypes.indexOf(type) < 0) {
         throw new Error('You do not have a resolver for ' + importInfo.type + ' types.');
       }

--- a/lib/resolvers/ember-app.js
+++ b/lib/resolvers/ember-app.js
@@ -7,22 +7,22 @@ var fs                      = require('fs-extra');
 
 module.exports = {
   resolve: function(destDir, importInfo, prePackager) {
-    var descriptor = prePackager.treeDescriptors[importInfo.pkgName];
-    var imprt = importInfo.name;
-    var pkg = importInfo.pkgName;
-    var srcDir = prePackager.treeDescriptors[pkg].srcDir;
-    var dependency = path.join(srcDir, imprt);
-    var destination = path.join(destDir, imprt);
-    var depGraphFile = pkg + path.sep + 'dep-graph.json';
+    var descriptor = prePackager.treeDescriptors[importInfo.packageName];
+    var importName = importInfo.name;
+    var packageName = importInfo.packageName;
+    var srcDir = prePackager.treeDescriptors[packageName].srcDir;
+    var dependency = path.join(srcDir, importName + '.js');
+    var destination = path.join(destDir, importName + '.js');
+    var depGraphFile = packageName + path.sep + 'dep-graph.json';
     var depGraphSource = path.join(srcDir, depGraphFile);
     var depGraphDestination = path.join(destDir, depGraphFile);
     var depGraph = fs.readJSONSync(depGraphSource);
 
     AllDependencies.update(descriptor, depGraph);
 
-    syncForwardDependencies(pkg, depGraphDestination, depGraphSource, depGraphFile);
-    syncForwardDependencies(pkg, destination + '.js', dependency + '.js', imprt + '.js');
-    var depsFor = AllDependencies.for(imprt, pkg);
-    return prePackager.selectResolution(pkg, depsFor);
+    syncForwardDependencies(packageName, depGraphDestination, depGraphSource, depGraphFile);
+    syncForwardDependencies(packageName, destination, dependency, importName + '.js');
+    var depsFor = AllDependencies.for(importName, packageName);
+    return prePackager.selectResolution(packageName, depsFor);
   }
 };

--- a/lib/resolvers/ember-app.js
+++ b/lib/resolvers/ember-app.js
@@ -13,14 +13,15 @@ module.exports = {
     var srcDir = prePackager.treeDescriptors[pkg].srcDir;
     var dependency = path.join(srcDir, imprt);
     var destination = path.join(destDir, imprt);
-    var depGraphSource = path.join(srcDir, pkg, 'dep-graph.json');
-    var depGraphDestination = path.join(destDir, pkg, 'dep-graph.json');
+    var depGraphFile = pkg + path.sep + 'dep-graph.json';
+    var depGraphSource = path.join(srcDir, depGraphFile);
+    var depGraphDestination = path.join(destDir, depGraphFile);
     var depGraph = fs.readJSONSync(depGraphSource);
 
     AllDependencies.update(descriptor, depGraph);
 
-    syncForwardDependencies(pkg, depGraphDestination, depGraphSource);
-    syncForwardDependencies(pkg, destination + '.js', dependency + '.js');
+    syncForwardDependencies(pkg, depGraphDestination, depGraphSource, depGraphFile);
+    syncForwardDependencies(pkg, destination + '.js', dependency + '.js', imprt + '.js');
     var depsFor = AllDependencies.for(imprt, pkg);
     return prePackager.selectResolution(pkg, depsFor);
   }

--- a/lib/resolvers/ember-app.js
+++ b/lib/resolvers/ember-app.js
@@ -19,8 +19,8 @@ module.exports = {
 
     AllDependencies.update(descriptor, depGraph);
 
-    syncForwardDependencies(depGraphDestination, depGraphSource);
-    syncForwardDependencies(destination + '.js', dependency + '.js');
+    syncForwardDependencies(pkg, depGraphDestination, depGraphSource);
+    syncForwardDependencies(pkg, destination + '.js', dependency + '.js');
     var depsFor = AllDependencies.for(imprt, pkg);
     return prePackager.selectResolution(pkg, depsFor);
   }

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -53,10 +53,11 @@ module.exports = {
     return mod;
   },
 
-  syncForwardDependencies: function(destination, source) {
+  syncForwardDependencies: function(packageName, destination, source) {
     if (!fs.existsSync(destination)) {
       fs.mkdirsSync(path.dirname(destination));
       fs.writeFileSync(destination, source);
+      AllDependencies.synced(packageName, destination);
     }
   },
 
@@ -100,7 +101,7 @@ module.exports = {
 
     mod = this.compileThroughCache(fs.readFileSync(importPath, 'utf8'), importName, basePath);
 
-    this.syncForwardDependencies(destinationPath, mod.code);
+    this.syncForwardDependencies(packageName, destinationPath, mod.code);
     AllDependencies.add(descriptor, relativePath, mod.deps);
     return AllDependencies.for(relativePath, pkg.name);
   },

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -6,6 +6,8 @@ var path            = require('path');
 var esperanto       = require('esperanto');
 var babel           = require('babel-core');
 var Descriptor      = require('../models/descriptor');
+var quickTemp       = require('quick-temp');
+var syncForwardDependencies = require('../utils/sync-forward-dependencies');
 
 module.exports = {
   extension: '.js',
@@ -53,12 +55,10 @@ module.exports = {
     return mod;
   },
 
-  syncForwardDependencies: function(packageName, destination, source) {
-    if (!fs.existsSync(destination)) {
-      fs.mkdirsSync(path.dirname(destination));
-      fs.writeFileSync(destination, source);
-      AllDependencies.synced(packageName, destination);
-    }
+  syncForwardDependency: function(packageName, destination, tmpPath, source) {
+    fs.mkdirsSync(path.dirname(tmpPath));
+    fs.writeFileSync(tmpPath, source);
+    syncForwardDependencies(packageName, destination, tmpPath);
   },
 
   materializeGraph: function(destination, nodeModulesPath, imports, packageName) {
@@ -72,6 +72,7 @@ module.exports = {
     var root = path.join(nodeModulesPath, packageName);
     var pkg = fs.readJSONSync(path.join(root, 'package.json'));
     var importNodeModulesPath = path.join(root, 'node_modules');
+    var tmpModules = quickTemp.makeOrReuse(this, 'tmpModules');
     var descriptor = new Descriptor({
       root: root,
       pkg: pkg,
@@ -85,23 +86,26 @@ module.exports = {
     var importPath;
     var mod;
     var basePath;
+    var tmpPath;
 
     if (isMain) {
       file = pkg['jsnext:main'] || pkg.main;
       relativePath = packageName + '/' + file.replace(path.extname(file), '');
       destinationPath = path.join(destination, pkg.name, file);
+      tmpPath = tmpModules + path.sep + pkg.name + path.sep + file;
       importPath = path.join(root, file);
       basePath = path.dirname(relativePath);
     } else {
       file = importName + this.extension;
       relativePath = importName;
       destinationPath = path.join(destination, file);
+      tmpPath = tmpModules + path.sep + file;
       importPath = path.join(nodeModulesPath, file);
     }
 
     mod = this.compileThroughCache(fs.readFileSync(importPath, 'utf8'), importName, basePath);
 
-    this.syncForwardDependencies(packageName, destinationPath, mod.code);
+    this.syncForwardDependency(packageName, destinationPath, tmpPath, mod.code);
     AllDependencies.add(descriptor, relativePath, mod.deps);
     return AllDependencies.for(relativePath, pkg.name);
   },

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -77,7 +77,7 @@ module.exports = {
       root: root,
       pkg: pkg,
       srcDir: tmpModules,
-      name: pkg.name,
+      packageName: pkg.name,
       nodeModulesPath: fs.existsSync(importNodeModulesPath) ? importNodeModulesPath : null
     });
     var isMain = packageName === importName;

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -43,13 +43,13 @@ module.exports = {
         mod.deps.imports = this.setBasePath(mod.deps.imports, basePath);
       }
       
-      this.cache = {
+      this.cache[importName] = {
         mod: mod,
         src: source
       };
       
     } else {
-      mod = this.cache.mod;
+      mod = cache.mod;
     }
 
     return mod;

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -68,7 +68,7 @@ module.exports = {
     }, this);
   },
 
-  resolveImport: function(destination, nodeModulesPath, packageName, importName, parentName) {
+  resolveImport: function(destination, nodeModulesPath, packageName, importName) {
     var root = path.join(nodeModulesPath, packageName);
     var pkg = fs.readJSONSync(path.join(root, 'package.json'));
     var importNodeModulesPath = path.join(root, 'node_modules');
@@ -115,9 +115,8 @@ module.exports = {
     var parentDescriptor = prePackager.treeDescriptors[importInfo.importer];
     var nodeModulesPath = parentDescriptor.nodeModulesPath;
     var importName = importInfo.name;
-    var packageName = importInfo.pkgName;
-    var parentName = parentDescriptor.name;
-    var nextImports = this.resolveImport(destDir, nodeModulesPath, packageName, importName, parentName);
+    var packageName = importInfo.packageName;
+    var nextImports = this.resolveImport(destDir, nodeModulesPath, packageName, importName);
     this.materializeGraph(destDir, nodeModulesPath, nextImports, packageName);
   }
 };

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -55,10 +55,10 @@ module.exports = {
     return mod;
   },
 
-  syncForwardDependency: function(packageName, destination, tmpPath, source) {
+  syncForwardDependency: function(packageName, destination, tmpPath, source, importPath) {
     fs.mkdirsSync(path.dirname(tmpPath));
     fs.writeFileSync(tmpPath, source);
-    syncForwardDependencies(packageName, destination, tmpPath);
+    syncForwardDependencies(packageName, destination, tmpPath, importPath);
   },
 
   materializeGraph: function(destination, nodeModulesPath, imports, packageName) {
@@ -68,7 +68,7 @@ module.exports = {
     }, this);
   },
 
-  resolveImport: function(destination, nodeModulesPath, packageName, importName) {
+  resolveImport: function(destination, nodeModulesPath, packageName, importName, parentName) {
     var root = path.join(nodeModulesPath, packageName);
     var pkg = fs.readJSONSync(path.join(root, 'package.json'));
     var importNodeModulesPath = path.join(root, 'node_modules');
@@ -76,6 +76,7 @@ module.exports = {
     var descriptor = new Descriptor({
       root: root,
       pkg: pkg,
+      srcDir: tmpModules,
       name: pkg.name,
       nodeModulesPath: fs.existsSync(importNodeModulesPath) ? importNodeModulesPath : null
     });
@@ -105,7 +106,7 @@ module.exports = {
 
     mod = this.compileThroughCache(fs.readFileSync(importPath, 'utf8'), importName, basePath);
 
-    this.syncForwardDependency(packageName, destinationPath, tmpPath, mod.code);
+    this.syncForwardDependency(pkg.name, destinationPath, tmpPath, mod.code, relativePath + this.extension);
     AllDependencies.add(descriptor, relativePath, mod.deps);
     return AllDependencies.for(relativePath, pkg.name);
   },
@@ -115,7 +116,8 @@ module.exports = {
     var nodeModulesPath = parentDescriptor.nodeModulesPath;
     var importName = importInfo.name;
     var packageName = importInfo.pkgName;
-    var nextImports = this.resolveImport(destDir, nodeModulesPath, packageName, importName);
+    var parentName = parentDescriptor.name;
+    var nextImports = this.resolveImport(destDir, nodeModulesPath, packageName, importName, parentName);
     this.materializeGraph(destDir, nodeModulesPath, nextImports, packageName);
   }
 };

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -7,7 +7,9 @@ var browserify  = require('browserify');
 var path        = require('path');
 var fs          = require('fs-extra');
 var mapSeries   = require('promise-map-series');
-var hashForDep   = require('hash-for-dep');
+var hashForDep  = require('hash-for-dep');
+var quickTemp   = require('quick-temp');
+var syncForwardDependencies = require('../utils/sync-forward-dependencies');
 
 function generateStub(moduleName) {
   return 'define("npm:' + moduleName + '", function() {' +
@@ -31,18 +33,19 @@ module.exports = {
     return b;
   },
 
-  updateCache: function(entryFile, basedir, outpath) {
+  updateCache: function(stubPath, packageName, basedir, outpath) {
     return new RSVP.Promise(function(resolve, reject) {
-      this.bundler(entryFile, basedir).bundle(function(err, data) {
-        var out = path.join(outpath, 'browserified', entryFile.split('browserified')[1]);
+      this.bundler(stubPath, basedir).bundle(function(err, data) {
+        var file = stubPath.split('browserified')[1];
+        var out = path.join(outpath, 'browserified', file);
+        var tmpPath = this.tmpBrowserify + file;
         if (err) {
           reject(err);
         }
 
-        fs.mkdirsSync(path.dirname(out));
-        fs.writeFileSync(out, data);
-
-        this.cache[basedir].buffer = data;
+        fs.mkdirsSync(path.dirname(tmpPath));
+        fs.writeFileSync(tmpPath, data);
+        syncForwardDependencies(packageName, out, tmpPath);
 
         resolve();
       }.bind(this));
@@ -69,6 +72,7 @@ module.exports = {
     var stubPath = options.stubPath;
     var destDir = options.destDir;
     var outputPath = options.outputPath;
+    var file = stubPath.split('browserified')[1];
 
     if (!cache || cache.stub !== stub || !hashesValid(pkg, parentRoot, cache)) {
       this.cache[parentRoot] = {
@@ -78,13 +82,12 @@ module.exports = {
 
       fs.writeFileSync(stubPath, stub);
 
-      return this.updateCache(stubPath, parentRoot, destDir).then(function() {
+      return this.updateCache(stubPath, pkg, parentRoot, destDir).then(function() {
         fs.removeSync(path.join(parentRoot, 'browserified'));
       });
     }
 
-    fs.mkdirsSync(path.dirname(outputPath));
-    fs.writeFileSync(outputPath, cache.buffer);
+    syncForwardDependencies(pkg, outputPath, this.tmpBrowserifyPath + path.sep + file);
   },
 
   resolveLater: function(destDir, importCache) {
@@ -99,6 +102,8 @@ module.exports = {
       var stub = imports.map(function(imprt) {
         return generateStub(imprt.name);
       }).join('');
+
+      quickTemp.makeOrReuse(this, 'tmpBrowserify');
 
       fs.mkdirsSync(path.dirname(stubPath));
 

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -95,7 +95,7 @@ module.exports = {
   resolveLater: function(destDir, importCache) {
     return mapSeries(Object.keys(importCache), function(packageName) {
       var parentDescriptor = importCache[packageName].parent.descriptor;
-      var parentName = parentDescriptor.name;
+      var parentName = parentDescriptor.packageName;
       var imports = importCache[packageName].imports;
       var parentRoot = parentDescriptor.root;
       var parentNodeModulesPath = parentDescriptor.nodeModulesPath;

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -74,7 +74,7 @@ module.exports = {
     var stubPath = options.stubPath;
     var destDir = options.destDir;
     var outputPath = options.outputPath;
-    var file = path.basename(stubPath.split('browserified')[1]);
+    var tmpPath = options.tmpPath;
 
     if (!cache || cache.stub !== stub || !hashesValid(packageName, parentRoot, cache)) {
       this.cache[parentRoot] = {
@@ -89,7 +89,7 @@ module.exports = {
       });
     }
 
-    syncForwardDependencies(packageName, outputPath, this.tmpBrowserifyPath + path.sep + file, file);
+    syncForwardDependencies(packageName, outputPath, tmpPath);
   },
 
   resolveLater: function(destDir, importCache) {
@@ -138,6 +138,7 @@ module.exports = {
         stubPath: stubPath,
         destDir: destDir,
         parentName: parentName,
+        tmpPath: path.join(tmpBrowserify, 'browserified', parentName, parentName + '-legacy.js'),
         outputPath: path.join(destDir, 'browserified', parentName, parentName + '-legacy.js')
       });
     }, this);

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -10,8 +10,8 @@ var mapSeries               = require('promise-map-series');
 var hashForDep              = require('hash-for-dep');
 var quickTemp               = require('quick-temp');
 var syncForwardDependencies = require('../utils/sync-forward-dependencies');
-var Descriptor              = require('../models/descriptor');
 var AllDependencies         = require('../all-dependencies');
+var resolveNodeModulePath   = require('node-modules-path');
 
 function generateStub(moduleName) {
   return 'define("npm:' + moduleName + '", function() {' +
@@ -102,29 +102,34 @@ module.exports = {
       var cache = this.cache[parentRoot];
       var stubPath = path.join(path.resolve('tmp', 'browserified', parentName), parentName + '-legacy.js');
       var tmpNodeModulesPath = path.join(path.dirname(stubPath), 'node_modules');
+      var relativePath = parentName + path.sep + parentName + path.sep + parentName + '-legacy.js';
+      var tmpBrowserify = quickTemp.makeOrReuse(this, 'tmpBrowserify');
+      var root = parentNodeModulesPath + path.sep + packageName;
+      var nodeModulesPath = resolveNodeModulePath(root);
+      var pkg = fs.readJSONSync(root + path.sep + 'package.json');
+      var dependencies = {};
       var stub = imports.map(function(imprt) {
         return generateStub(imprt.name);
       }).join('');
-      var relativePath = parentName + path.sep + parentName + path.sep + parentName + '-legacy.js';
-      var dependencies = {};
-      dependencies[relativePath] = { imports: [], exports: [] }
 
-      quickTemp.makeOrReuse(this, 'tmpBrowserify');
+      // NPM modules are obaque but we need this to update the graph
+      dependencies[relativePath] = { imports: [], exports: [] };
 
       fs.mkdirsSync(path.dirname(stubPath));
 
-      AllDependencies.update(new Descriptor({
-        root: parentRoot + path.sep + packageName,
+      AllDependencies.update({
+        root: root,
         packageName: packageName,
-        nodeModulesPath: parentNodeModulesPath + path.sep + packageName + path.sep + 'node_modules',
-        pkg: fs.readJSONSync(parentNodeModulesPath + path.sep + packageName + path.sep + 'package.json'),
+        nodeModulesPath: nodeModulesPath,
+        pkg: pkg,
         relativePath: [relativePath],
         parent: parentDescriptor,
         name: packageName,
-        srcDir: this.tmpBrowserify
-      }), dependencies);
+        srcDir: tmpBrowserify
+      }, dependencies);
 
       this.syncNodeModules(parentDescriptor.nodeModulesPath, tmpNodeModulesPath);
+
       return this.updateThroughCache({
         cache: cache,
         stub: stub,

--- a/lib/resolvers/npm.js
+++ b/lib/resolvers/npm.js
@@ -1,15 +1,17 @@
 'use strict';
 
-var array       = require('../utils/array');
-var equal       = array.equal;
-var RSVP        = require('rsvp');
-var browserify  = require('browserify');
-var path        = require('path');
-var fs          = require('fs-extra');
-var mapSeries   = require('promise-map-series');
-var hashForDep  = require('hash-for-dep');
-var quickTemp   = require('quick-temp');
+var array                   = require('../utils/array');
+var equal                   = array.equal;
+var RSVP                    = require('rsvp');
+var browserify              = require('browserify');
+var path                    = require('path');
+var fs                      = require('fs-extra');
+var mapSeries               = require('promise-map-series');
+var hashForDep              = require('hash-for-dep');
+var quickTemp               = require('quick-temp');
 var syncForwardDependencies = require('../utils/sync-forward-dependencies');
+var Descriptor              = require('../models/descriptor');
+var AllDependencies         = require('../all-dependencies');
 
 function generateStub(moduleName) {
   return 'define("npm:' + moduleName + '", function() {' +
@@ -36,16 +38,16 @@ module.exports = {
   updateCache: function(stubPath, packageName, basedir, outpath) {
     return new RSVP.Promise(function(resolve, reject) {
       this.bundler(stubPath, basedir).bundle(function(err, data) {
-        var file = stubPath.split('browserified')[1];
-        var out = path.join(outpath, 'browserified', file);
-        var tmpPath = this.tmpBrowserify + file;
+        var file = 'browserified' + path.sep + stubPath.split('browserified')[1].slice(1);
+        var out = path.join(outpath, file);
+        var tmpPath = this.tmpBrowserify + path.sep + file;
         if (err) {
           reject(err);
         }
 
         fs.mkdirsSync(path.dirname(tmpPath));
         fs.writeFileSync(tmpPath, data);
-        syncForwardDependencies(packageName, out, tmpPath);
+        syncForwardDependencies(packageName, out, tmpPath, file);
 
         resolve();
       }.bind(this));
@@ -67,54 +69,70 @@ module.exports = {
   updateThroughCache: function(options) {
     var cache = options.cache;
     var stub = options.stub;
-    var pkg = options.pkg;
+    var packageName = options.packageName;
     var parentRoot = options.parentRoot;
     var stubPath = options.stubPath;
     var destDir = options.destDir;
     var outputPath = options.outputPath;
-    var file = stubPath.split('browserified')[1];
+    var file = path.basename(stubPath.split('browserified')[1]);
 
-    if (!cache || cache.stub !== stub || !hashesValid(pkg, parentRoot, cache)) {
+    if (!cache || cache.stub !== stub || !hashesValid(packageName, parentRoot, cache)) {
       this.cache[parentRoot] = {
         stub: stub,
-        hash: hashForDep(pkg ,parentRoot)
+        hash: hashForDep(packageName ,parentRoot)
       };
 
       fs.writeFileSync(stubPath, stub);
 
-      return this.updateCache(stubPath, pkg, parentRoot, destDir).then(function() {
+      return this.updateCache(stubPath, packageName, parentRoot, destDir).then(function() {
         fs.removeSync(path.join(parentRoot, 'browserified'));
       });
     }
 
-    syncForwardDependencies(pkg, outputPath, this.tmpBrowserifyPath + path.sep + file);
+    syncForwardDependencies(packageName, outputPath, this.tmpBrowserifyPath + path.sep + file, file);
   },
 
   resolveLater: function(destDir, importCache) {
-    return mapSeries(Object.keys(importCache), function(pkg) {
-      var parentDescriptor = importCache[pkg].parent.descriptor;
+    return mapSeries(Object.keys(importCache), function(packageName) {
+      var parentDescriptor = importCache[packageName].parent.descriptor;
       var parentName = parentDescriptor.name;
-      var imports = importCache[pkg].imports;
+      var imports = importCache[packageName].imports;
       var parentRoot = parentDescriptor.root;
+      var parentNodeModulesPath = parentDescriptor.nodeModulesPath;
       var cache = this.cache[parentRoot];
       var stubPath = path.join(path.resolve('tmp', 'browserified', parentName), parentName + '-legacy.js');
       var tmpNodeModulesPath = path.join(path.dirname(stubPath), 'node_modules');
       var stub = imports.map(function(imprt) {
         return generateStub(imprt.name);
       }).join('');
+      var relativePath = parentName + path.sep + parentName + path.sep + parentName + '-legacy.js';
+      var dependencies = {};
+      dependencies[relativePath] = { imports: [], exports: [] }
 
       quickTemp.makeOrReuse(this, 'tmpBrowserify');
 
       fs.mkdirsSync(path.dirname(stubPath));
 
+      AllDependencies.update(new Descriptor({
+        root: parentRoot + path.sep + packageName,
+        packageName: packageName,
+        nodeModulesPath: parentNodeModulesPath + path.sep + packageName + path.sep + 'node_modules',
+        pkg: fs.readJSONSync(parentNodeModulesPath + path.sep + packageName + path.sep + 'package.json'),
+        relativePath: [relativePath],
+        parent: parentDescriptor,
+        name: packageName,
+        srcDir: this.tmpBrowserify
+      }), dependencies);
+
       this.syncNodeModules(parentDescriptor.nodeModulesPath, tmpNodeModulesPath);
       return this.updateThroughCache({
         cache: cache,
         stub: stub,
-        pkg: pkg,
+        packageName: packageName,
         parentRoot: parentRoot,
         stubPath: stubPath,
         destDir: destDir,
+        parentName: parentName,
         outputPath: path.join(destDir, 'browserified', parentName, parentName + '-legacy.js')
       });
     }, this);

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -24,7 +24,7 @@ function equal(a, b) {
     return true;
   }
 
-  if (a === null || b === null) {
+  if (a === undefined || b === undefined || a === null || b === null) {
     return false;
   }
 

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -57,12 +57,16 @@ function flatten(array) {
   });
 }
 
-function without(array, exclusions) {
-  return array.filter(function(item) { return exclusions.indexOf(item) < 0; });
-}
-
 function intersect(array1, array2) {
   return array1.filter(function(item) { return array2.indexOf(item) !== -1; });
+}
+
+function without(array, exclusions) {
+  return array.filter(function(item) {
+    return !exclusions.some(function(exclude) {
+      return item === exclude;
+    });
+  });
 }
 
 function head(array) {

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -58,11 +58,11 @@ function flatten(array) {
 }
 
 function diff(array, exclusions) {
-  return array.filter(function(item) { return exclusions.indexOf(item) < 0 });
+  return array.filter(function(item) { return exclusions.indexOf(item) < 0; });
 }
 
 function intersect(array1, array2) {
-  return array1.filter(function(item) { return array2.indexOf(item) !== -1 });
+  return array1.filter(function(item) { return array2.indexOf(item) !== -1; });
 }
 
 function without(array, exclusions) {

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -57,7 +57,7 @@ function flatten(array) {
   });
 }
 
-function diff(array, exclusions) {
+function without(array, exclusions) {
   return array.filter(function(item) { return exclusions.indexOf(item) < 0; });
 }
 
@@ -65,16 +65,8 @@ function intersect(array1, array2) {
   return array1.filter(function(item) { return array2.indexOf(item) !== -1; });
 }
 
-function without(array, exclusions) {
-  return array.filter(function(item) {
-    return !exclusions.some(function(exclude) {
-      return item === exclude;
-    });
-  });
-}
-
 function head(array) {
-  return array[array.length - 1];
+  return array[0];
 }
 
 module.exports = {
@@ -84,7 +76,6 @@ module.exports = {
   compact: compact,
   contains: contains,
   flatten: flatten,
-  diff: diff,
   without: without,
   intersect: intersect,
   head: head

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -51,10 +51,17 @@ var contains = (function() {
   };
 })();
 
+function flatten(array) {
+  return array.reduce(function(a, b) {
+    return a.concat(b);
+  });
+}
+
 module.exports = {
   zip: zip,
   uniq: uniq,
   equal: equal,
   compact: compact,
-  contains: contains
+  contains: contains,
+  flatten: flatten
 };

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -57,11 +57,35 @@ function flatten(array) {
   });
 }
 
+function diff(array, exclusions) {
+  return array.filter(function(item) { return exclusions.indexOf(item) < 0 });
+}
+
+function intersect(array1, array2) {
+  return array1.filter(function(item) { return array2.indexOf(item) !== -1 });
+}
+
+function without(array, exclusions) {
+  return array.filter(function(item) {
+    return !exclusions.some(function(exclude) {
+      return item === exclude;
+    });
+  });
+}
+
+function head(array) {
+  return array[array.length - 1];
+}
+
 module.exports = {
   zip: zip,
   uniq: uniq,
   equal: equal,
   compact: compact,
   contains: contains,
-  flatten: flatten
+  flatten: flatten,
+  diff: diff,
+  without: without,
+  intersect: intersect,
+  head: head
 };

--- a/lib/utils/get-import-info.js
+++ b/lib/utils/get-import-info.js
@@ -48,7 +48,7 @@ function esFromNodeModules(importer, packageName, importee) {
 function appOrAddon(descriptor, importer, importee) {
   return new Import({
     importer: importer,
-    packageName: descriptor.name,
+    packageName: descriptor.packageName,
     name: importee,
     type: 'ember-app'
   });

--- a/lib/utils/get-import-info.js
+++ b/lib/utils/get-import-info.js
@@ -30,7 +30,7 @@ function customImport(descriptor, importer, resolverParts) {
 
   return new Import({
     importer: importer,
-    pkgName: packageName,
+    packageName: packageName,
     name: name,
     type: type
   });
@@ -39,7 +39,7 @@ function customImport(descriptor, importer, resolverParts) {
 function esFromNodeModules(importer, packageName, importee) {
   return new Import({
     importer: importer,
-    pkgName: packageName,
+    packageName: packageName,
     name: importee,
     type: 'es'
   });
@@ -48,7 +48,7 @@ function esFromNodeModules(importer, packageName, importee) {
 function appOrAddon(descriptor, importer, importee) {
   return new Import({
     importer: importer,
-    pkgName: descriptor.name,
+    packageName: descriptor.name,
     name: importee,
     type: 'ember-app'
   });

--- a/lib/utils/sync-forward-dependencies.js
+++ b/lib/utils/sync-forward-dependencies.js
@@ -3,10 +3,12 @@
 var fs                = require('fs-extra');
 var path              = require('path');
 var symlinkOrCopySync = require('symlink-or-copy').sync;
+var AllDependencies   = require('../all-dependencies');
 
-module.exports = function(destination, dependency) {
+module.exports = function(packageName, destination, dependency) {
   if (!fs.existsSync(destination)) {
     fs.mkdirsSync(path.dirname(destination));
     symlinkOrCopySync(dependency, destination);
+    AllDependencies.synced(packageName, dependency);
   }
 };

--- a/lib/utils/sync-forward-dependencies.js
+++ b/lib/utils/sync-forward-dependencies.js
@@ -5,10 +5,12 @@ var path              = require('path');
 var symlinkOrCopySync = require('symlink-or-copy').sync;
 var AllDependencies   = require('../all-dependencies');
 
-module.exports = function(packageName, destination, dependency) {
+module.exports = function(packageName, destination, dependency, relativePath, skipCache) {
   if (!fs.existsSync(destination)) {
     fs.mkdirsSync(path.dirname(destination));
     symlinkOrCopySync(dependency, destination);
-    AllDependencies.synced(packageName, dependency);
+    if (!skipCache) {
+      AllDependencies.synced(packageName, relativePath);
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "resolve": "^1.1.6",
     "rsvp": "^3.0.18",
     "symlink-or-copy": "^1.0.1",
-    "walk-sync": "^0.1.3"
+    "walk-sync": "^0.1.3",
+    "quick-temp": "^0.1.2"
   },
   "devDependencies": {
     "broccoli-stew": "^0.2.1",
@@ -38,7 +39,6 @@
     "glob": "^5.0.6",
     "istanbul": "^0.3.14",
     "mocha": "^2.2.1",
-    "quick-temp": "^0.1.2",
     "sinon": "^1.14.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-core": "^5.3.3",
-    "broccoli-kitchen-sink-helpers": "^0.2.6",
+    "broccoli-kitchen-sink-helpers": "^0.2.7",
     "browserify": "^9.0.3",
     "core-object": "^1.1.0",
     "debug": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "fs-extra": "^0.17.0",
     "hash-for-dep": "0.0.3",
     "lodash-node": "^3.6.0",
+    "node-modules-path": "^1.0.1",
     "promise-map-series": "^0.2.1",
+    "quick-temp": "^0.1.2",
     "resolve": "^1.1.6",
     "rsvp": "^3.0.18",
     "symlink-or-copy": "^1.0.1",
-    "walk-sync": "^0.1.3",
-    "quick-temp": "^0.1.2"
+    "walk-sync": "^0.1.3"
   },
   "devDependencies": {
     "broccoli-stew": "^0.2.1",

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -130,6 +130,10 @@ describe('pre-package acceptance', function () {
       expect(babelified.indexOf('...args')).to.be.lt(0);
     });
   });
+
+  it('should just sync all the files if the graph is stable', function() {
+    
+  });
   
   // TODO
   // Spying on functions with broccoli-test-helpers is no bueno

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -18,7 +18,7 @@ function clone(a) {
    return JSON.parse(JSON.stringify(a));
 }
 
-describe.skip('pre-package acceptance', function () {
+describe('pre-package acceptance', function () {
   var fixturePath = path.resolve('./tests/fixtures/example-app');
   var testSubject = function() {
       return new PrePackager(arguments[0], arguments[1]);
@@ -75,7 +75,7 @@ describe.skip('pre-package acceptance', function () {
     });
   });
 
-  it('should remove files from the output if the imports are removed', function () {
+  it.skip('should remove files from the output if the imports are removed', function () {
     var graphPath = path.join(process.cwd(), 'tests/fixtures/example-app/tree/example-app/dep-graph.json');
     var graph = fs.readJSONSync(graphPath);
     var graphClone = clone(graph);
@@ -120,7 +120,8 @@ describe.skip('pre-package acceptance', function () {
     });
   });
 
-  it('should transpile regular es6 modules', function() {
+  it.skip('should transpile regular es6 modules', function() {
+    console.log(paths);
     return prePackager(generateTrees(paths), {
       entries: ['example-app'],
       treeDescriptors: generateTreeDescriptors(paths)
@@ -130,14 +131,10 @@ describe.skip('pre-package acceptance', function () {
       expect(babelified.indexOf('...args')).to.be.lt(0);
     });
   });
-
-  it('should just sync all the files if the graph is stable', function() {
-    
-  });
   
   // TODO
   // Spying on functions with broccoli-test-helpers is no bueno
-  describe('node_modules rebuild', function() {
+  describe.skip('node_modules rebuild', function() {
     beforeEach(function() {
       prePackager = makeTestHelper({
         fixturePath: fixturePath,

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -18,7 +18,7 @@ function clone(a) {
    return JSON.parse(JSON.stringify(a));
 }
 
-describe('pre-package acceptance', function () {
+describe.skip('pre-package acceptance', function () {
   var fixturePath = path.resolve('./tests/fixtures/example-app');
   var testSubject = function() {
       return new PrePackager(arguments[0], arguments[1]);

--- a/tests/helpers/generate-tree-descriptors.js
+++ b/tests/helpers/generate-tree-descriptors.js
@@ -23,7 +23,7 @@ function generateTreeDescriptors(paths) {
     pkg = require(path.join(root, 'package.json'));
 
     descriptors[pkg.name] = {
-      name: pkg.name,
+      packageName: pkg.name,
       pkg: pkg,
       root: root,
       nodeModulesPath: nodeModulesPath

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -4,11 +4,14 @@ var AllDependencies = require('../../lib/all-dependencies');
 var Dependency = require('../../lib/models/dependency');
 var Descriptor = require('../../lib/models/descriptor');
 var expect = require('chai').expect;
-var clone = require('../../lib/utils/array').clone;
 
+function modelEquals(result, expectation) {
+  Object.keys(result).forEach(function(key) {
+    expect(result[key]).to.deep.equal(expectation[key]);
+  });
+}
 
 var descriptor = {
-  name: 'example-app',
   root: '/workspace/example-app',
   packageName: 'example-app',
   srcDir: 'foo/bar/baz_tmp',
@@ -37,7 +40,7 @@ var dependencies = {
   }
 };
 
-describe('all dependencies unit', function() {
+describe.only('all dependencies unit', function() {
 
   beforeEach(function () {
     AllDependencies._graph = {};
@@ -139,16 +142,18 @@ describe('all dependencies unit', function() {
         pkg: { name: 'bazing', version: '9000.0.0' },
         relativePaths: undefined,
         parent: undefined,
-        name: 'bazing',
         srcDir: 'foo/bar/tmp_fizzy'
       };
       AllDependencies.add(desc, 'bazing/a', { imports: ['bazing/b'] });
       var dependency = AllDependencies.for('bazing');
-
-      expect(dependency.descriptor).to.deep.eql(new Descriptor(desc));
-      expect(dependency.graph).to.deep.eql({ 'bazing/a': { imports: [ 'bazing/b' ] } });
-      expect(dependency.imports).to.deep.eql({ 'bazing/a': [ 'bazing/b' ] });
+      modelEquals(dependency.descriptor, new Descriptor(desc));
+      expect(dependency.graph).to.deep.eql({
+        'bazing/a': { imports: [ 'bazing/b' ] }
+      });
       expect(dependency.dedupedImports).to.deep.eql([ 'bazing/b' ]);
+      expect(dependency.imports).to.deep.eql({
+        'bazing/a': [ 'bazing/b' ]
+      });
     }); 
 
     it('should add an item to the graph if it already exists', function() {
@@ -159,14 +164,13 @@ describe('all dependencies unit', function() {
         pkg: { name: 'bazing', version: '9000.0.0' },
         relativePaths: undefined,
         parent: undefined,
-        name: 'bazing',
         srcDir: 'foo/bar/tmp_fizzy'
       };
       AllDependencies.add(desc, 'bazing/a', { imports: ['bazing/b'] });
       AllDependencies.add(desc, 'bazing/b', { imports: [] });
       var dependency = AllDependencies.for('bazing');
 
-      expect(dependency.descriptor).to.deep.eql(new Descriptor(desc));
+      modelEquals(dependency.descriptor, new Descriptor(desc));
       expect(dependency.graph).to.deep.eql({
         'bazing/a': { imports: [ 'bazing/b' ] },
         'bazing/b': { imports: [] }

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var AllDependencies = require('../../lib/all-dependencies');
-var Dependency = require('../../lib/models/dependency');
+var Package = require('../../lib/models/package');
 var Descriptor = require('../../lib/models/descriptor');
 var expect = require('chai').expect;
 
@@ -48,9 +48,9 @@ describe.only('all dependencies unit', function() {
   });
 
   describe('update', function () {
-    it('should update the graph with a new Dependency model', function() {
+    it('should update the graph with a new Package model', function() {
       AllDependencies.update(descriptor, dependencies);
-      expect(AllDependencies._graph['example-app'] instanceof Dependency);
+      expect(AllDependencies._graph['example-app'] instanceof Package);
     });
 
     it('should wrap the descriptor in a Descriptor model', function() {
@@ -58,9 +58,9 @@ describe.only('all dependencies unit', function() {
       expect(AllDependencies._graph['example-app'].descriptor instanceof Descriptor);
     });
 
-    it('should add the dependency to the graph', function() {
+    it('should add the package to the graph', function() {
       AllDependencies.update(descriptor, dependencies);
-      expect(AllDependencies._graph['example-app']).to.deep.eql(new Dependency({
+      expect(AllDependencies._graph['example-app']).to.deep.eql(new Package({
         descriptor: new Descriptor(descriptor),
         graph: dependencies,
         imports: {
@@ -75,7 +75,7 @@ describe.only('all dependencies unit', function() {
   describe('for', function() {
     it('should return a graph for a package', function() {
       AllDependencies.update(descriptor, dependencies);
-      expect(AllDependencies.for('example-app')).to.deep.equal(new Dependency({
+      expect(AllDependencies.for('example-app')).to.deep.equal(new Package({
         descriptor: new Descriptor(descriptor),
         graph: dependencies,
         imports: {
@@ -145,13 +145,13 @@ describe.only('all dependencies unit', function() {
         srcDir: 'foo/bar/tmp_fizzy'
       };
       AllDependencies.add(desc, 'bazing/a', { imports: ['bazing/b'] });
-      var dependency = AllDependencies.for('bazing');
-      modelEquals(dependency.descriptor, new Descriptor(desc));
-      expect(dependency.graph).to.deep.eql({
+      var pack = AllDependencies.for('bazing');
+      modelEquals(pack.descriptor, new Descriptor(desc));
+      expect(pack.graph).to.deep.eql({
         'bazing/a': { imports: [ 'bazing/b' ] }
       });
-      expect(dependency.dedupedImports).to.deep.eql([ 'bazing/b' ]);
-      expect(dependency.imports).to.deep.eql({
+      expect(pack.dedupedImports).to.deep.eql([ 'bazing/b' ]);
+      expect(pack.imports).to.deep.eql({
         'bazing/a': [ 'bazing/b' ]
       });
     }); 
@@ -168,18 +168,18 @@ describe.only('all dependencies unit', function() {
       };
       AllDependencies.add(desc, 'bazing/a', { imports: ['bazing/b'] });
       AllDependencies.add(desc, 'bazing/b', { imports: [] });
-      var dependency = AllDependencies.for('bazing');
+      var pack = AllDependencies.for('bazing');
 
-      modelEquals(dependency.descriptor, new Descriptor(desc));
-      expect(dependency.graph).to.deep.eql({
+      modelEquals(pack.descriptor, new Descriptor(desc));
+      expect(pack.graph).to.deep.eql({
         'bazing/a': { imports: [ 'bazing/b' ] },
         'bazing/b': { imports: [] }
       });
-      expect(dependency.imports).to.deep.eql({
+      expect(pack.imports).to.deep.eql({
         'bazing/a': [ 'bazing/b' ],
         'bazing/b': [ ]
       });
-      expect(dependency.dedupedImports).to.deep.eql([ 'bazing/b' ]);
+      expect(pack.dedupedImports).to.deep.eql([ 'bazing/b' ]);
     }); 
   });
 });

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -40,7 +40,7 @@ var dependencies = {
   }
 };
 
-describe.only('all dependencies unit', function() {
+describe('all dependencies unit', function() {
 
   beforeEach(function () {
     AllDependencies._graph = {};

--- a/tests/unit/array-test.js
+++ b/tests/unit/array-test.js
@@ -39,4 +39,39 @@ describe('array', function() {
       expect(array.compact([1, 2, null, undefined, -1])).to.deep.eql([1,2, -1]);
     });
   });
+
+  describe('contains', function() {
+    it('should return true if the item is in the array', function() {
+      expect(array.contains([1,2,3], 1)).to.eql(true);
+    });
+
+    it('should return false if the item is in the array', function() {
+      expect(array.contains([1,2,3], 5)).to.eql(false);
+    });
+  });
+
+  describe('flatten', function() {
+    it('should flatten a 2d array', function() {
+      expect(array.flatten([[1], [2], [3]])).to.deep.eql([1,2,3]);
+    });
+  });
+
+  describe('without', function() {
+    it('should return an array without the values specified', function() {
+      var exclude = [2,3];
+      expect(array.without([1,2,3], exclude)).to.deep.eql([1]);
+    });
+  });
+
+  describe('intersect', function() {
+    it('should return the intersection of 2 arrays', function() {
+      expect(array.intersect([1,2,3], [1,4,5])).to.deep.eql([1]);
+    });
+  });
+
+  describe('head', function() {
+    it('should return the head of the array', function() {
+      expect(array.head([1,2,3])).to.deep.eql(1);
+    });
+  });
 });

--- a/tests/unit/dependency-test.js
+++ b/tests/unit/dependency-test.js
@@ -1,23 +1,23 @@
 'use strict';
-var Dependency = require('../../lib/models/dependency');
+var Package = require('../../lib/models/package');
 var expect = require('chai').expect;
 
-describe('dependency', function() {
+describe('Package', function() {
 
   beforeEach(function() {
-    this.dependency = new Dependency();
+    this.pack = new Package();
   });
 
   afterEach(function() {
-    this.dependency = null;
+    this.pack = null;
   });
 
   it('should add an import the graph', function() {
-    this.dependency.addToGraph('example-app/app', {
+    this.pack.addToGraph('example-app/app', {
       imports: ['exports', 'ember'],
       exports: ['default']
     });
-    expect(this.dependency.graph).to.deep.eql({
+    expect(this.pack.graph).to.deep.eql({
       'example-app/app': {
         imports: ['exports', 'ember'],
         exports: ['default']
@@ -26,15 +26,15 @@ describe('dependency', function() {
   });
 
   it('should add to dedupedImports', function() {
-    this.dependency.addToDedupedImports(['ember', 'jquery']);
-    expect(this.dependency.dedupedImports).to.deep.eql(['ember', 'jquery']);
-    this.dependency.addToDedupedImports(['ember', 'lodash']);
-    expect(this.dependency.dedupedImports).to.deep.eql(['ember', 'jquery', 'lodash']);
+    this.pack.addToDedupedImports(['ember', 'jquery']);
+    expect(this.pack.dedupedImports).to.deep.eql(['ember', 'jquery']);
+    this.pack.addToDedupedImports(['ember', 'lodash']);
+    expect(this.pack.dedupedImports).to.deep.eql(['ember', 'jquery', 'lodash']);
   });
 
   it('should add to imports', function() {
-    this.dependency.addToImports('example-app/app', ['ember', 'jquery']);
-    expect(this.dependency.imports).to.deep.eql({
+    this.pack.addToImports('example-app/app', ['ember', 'jquery']);
+    expect(this.pack.imports).to.deep.eql({
       'example-app/app': ['ember', 'jquery']
     });
   });

--- a/tests/unit/es-test.js
+++ b/tests/unit/es-test.js
@@ -22,7 +22,7 @@ describe('es resolver', function() {
   it('should sync forward non-main file it\'s imports', function() {
     var importInfo = new Import({
       importer: 'ember',
-      pkgName: 'lodash',
+      packageName: 'lodash',
       name: 'lodash/lib/array/uniq',
       type: 'es'
     });
@@ -41,7 +41,7 @@ describe('es resolver', function() {
   it('should sync forward main file it\'s imports', function() {
     var importInfo = new Import({
       importer: 'ember',
-      pkgName: 'lodash',
+      packageName: 'lodash',
       name: 'lodash',
       type: 'es'
     });

--- a/tests/unit/es-test.js
+++ b/tests/unit/es-test.js
@@ -8,7 +8,7 @@ var temp = require('quick-temp');
 var Import = require('../../lib/models/import');
 var expect = require('chai').expect;
 
-describe('es resolver', function() {
+describe.skip('es resolver', function() {
   var paths = walkSync('tests/fixtures/example-app/tree');
 
   beforeEach(function() {

--- a/tests/unit/es-test.js
+++ b/tests/unit/es-test.js
@@ -8,15 +8,15 @@ var temp = require('quick-temp');
 var Import = require('../../lib/models/import');
 var expect = require('chai').expect;
 
-describe.skip('es resolver', function() {
+describe('es resolver', function() {
   var paths = walkSync('tests/fixtures/example-app/tree');
 
   beforeEach(function() {
-    sinon.spy(resolver, 'syncForwardDependencies');
+    sinon.spy(resolver, 'syncForwardDependency');
   });
 
   afterEach(function() {
-    resolver.syncForwardDependencies.restore();
+    resolver.syncForwardDependency.restore();
   });
 
   it('should sync forward non-main file it\'s imports', function() {
@@ -32,10 +32,11 @@ describe.skip('es resolver', function() {
     resolver.resolve(tempDir, importInfo, {
       treeDescriptors: generateTreeDescriptors(paths)
     });
-    expect(resolver.syncForwardDependencies.callCount).to.eql(3);
-    expect(resolver.syncForwardDependencies.firstCall.args[0]).to.eql(tempDir + '/' + 'lodash/lib/array/uniq.js');
-    expect(resolver.syncForwardDependencies.secondCall.args[0]).to.eql(tempDir + '/' + 'lodash/lib/array/flatten.js');
-    expect(resolver.syncForwardDependencies.thirdCall.args[0]).to.eql(tempDir + '/' + 'lodash/lib/compat.js');
+
+    expect(resolver.syncForwardDependency.callCount).to.eql(3);
+    expect(resolver.syncForwardDependency.firstCall.args[4]).to.eql('lodash/lib/array/uniq.js');
+    expect(resolver.syncForwardDependency.secondCall.args[4]).to.eql('lodash/lib/array/flatten.js');
+    expect(resolver.syncForwardDependency.thirdCall.args[4]).to.eql('lodash/lib/compat.js');
   });
 
   it('should sync forward main file it\'s imports', function() {
@@ -51,11 +52,11 @@ describe.skip('es resolver', function() {
     resolver.resolve(tempDir, importInfo, {
       treeDescriptors: generateTreeDescriptors(paths)
     });
-    expect(resolver.syncForwardDependencies.callCount).to.eql(4);
-    expect(resolver.syncForwardDependencies.firstCall.args[0]).to.eql(tempDir + '/' + 'lodash/lib/lodash.js');
-    expect(resolver.syncForwardDependencies.secondCall.args[0]).to.eql(tempDir + '/' + 'lodash/lib/array/uniq.js');
-    expect(resolver.syncForwardDependencies.thirdCall.args[0]).to.eql(tempDir + '/' + 'lodash/lib/array/flatten.js');
-    expect(resolver.syncForwardDependencies.lastCall.args[0]).to.eql(tempDir + '/' + 'lodash/lib/compat.js');
+    expect(resolver.syncForwardDependency.callCount).to.eql(4);
+    expect(resolver.syncForwardDependency.firstCall.args[4]).to.eql('lodash/lib/lodash.js');
+    expect(resolver.syncForwardDependency.secondCall.args[4]).to.eql('lodash/lib/array/uniq.js');
+    expect(resolver.syncForwardDependency.thirdCall.args[4]).to.eql('lodash/lib/array/flatten.js');
+    expect(resolver.syncForwardDependency.lastCall.args[4]).to.eql('lodash/lib/compat.js');
   });
 
 });

--- a/tests/unit/get-import-info-test.js
+++ b/tests/unit/get-import-info-test.js
@@ -34,7 +34,7 @@ describe('getImportInfo', function() {
     expect(props.length).to.eql(4);
     expect(props).to.deep.eql([
       'importer',
-      'pkgName',
+      'packageName',
       'name',
       'type'
     ]);

--- a/tests/unit/pre-packager-test.js
+++ b/tests/unit/pre-packager-test.js
@@ -1,0 +1,339 @@
+'use strict';
+
+var PrePackager = require('../../lib/pre-packager');
+var expect = require('chai').expect;
+var walkSync = require('walk-sync');
+var generateTrees = require('../helpers/generate-trees');
+var AllDependencies = require('../../lib/all-dependencies');
+var generateTreeDescriptors = require('../helpers/generate-tree-descriptors');
+var path = require('path');
+var Import = require('../../lib/models/import');
+
+function generateGraphHashes() {
+  return {
+    'example-app':  {
+      name: 'example-app',
+      hash: '2ed8ffd474b4b640a931915d6b40f6f6',
+      graph: {
+        'example-app/a' : {
+          imports: ['example-app/b']
+        },
+        'example-app/b': {
+          imports: []
+        }
+      }
+    }
+  };
+}
+
+describe('PrePackager', function () {
+  var prePackager;
+  var paths = walkSync('tests/fixtures/example-app/tree');
+
+  beforeEach(function() {
+    AllDependencies._synced = {};
+    AllDependencies._graph = {};
+    prePackager = new PrePackager(generateTrees(paths), {
+      entries: ['example-app'],
+      treeDescriptors: generateTreeDescriptors(paths)
+    });
+  });
+
+  it('should throw if no entires are passed', function() {
+    expect(function() {
+      return new PrePackager();
+    }).to.throw(/You must pass an array of entries./);
+  });
+
+  it('should throw if no tree descriptors are passed', function() {
+    expect(function() {
+      return new PrePackager('.', { entries: ['example-app'] });
+    }).to.throw(/You must pass TreeDescriptors that describe the trees in the project./);
+  });
+
+  it('should setup graphHashes if they do not exist', function() {
+    prePackager.hashGraphs = function() {
+      return generateGraphHashes();
+    };
+
+    var diffs = prePackager.diffGraph();
+
+    expect(diffs).to.deep.eql([]);
+    expect(prePackager.graphHashes).to.deep.eql(generateGraphHashes());
+  });
+
+  describe('cacheImport', function() {
+    it('should cache an import by its type', function() {
+      AllDependencies.update({
+        root: process.cwd(),
+        nodeModulesPath: process.cwd() + path.sep + 'node_modules',
+        packageName: 'example-app',
+        pkg: { name: 'example-app', version: '1.0.0' },
+        relativePaths: ['example-app/', 'example-app/a.js', 'example-app/b.js'],
+        parent: null,
+        srcDir: process.cwd() + path.sep + 'tmp_foo'
+      }, {
+        'foo': {
+          imports: ['npm:a']
+        }
+      });
+
+      prePackager.cacheImport(new Import({
+        name: 'a',
+        packageName: 'sample-package',
+        type: 'npm',
+        importer: 'example-app'
+      }), 'example-app');
+
+      expect(prePackager.importCache).to.deep.eql({
+        npm: {
+          'sample-package': {
+            imports: [new Import({importer: 'example-app', name: 'a', packageName: 'sample-package', type: 'npm'})],
+            parent: AllDependencies.for('example-app')
+          }
+        }
+      });      
+    });
+
+    it('should update the existing import cache with a new import', function() {
+      AllDependencies.update({
+        root: process.cwd(),
+        nodeModulesPath: process.cwd() + path.sep + 'node_modules',
+        packageName: 'example-app',
+        pkg: { name: 'example-app', version: '1.0.0' },
+        relativePaths: ['example-app/', 'example-app/a.js', 'example-app/b.js'],
+        parent: null,
+        srcDir: process.cwd() + path.sep + 'tmp_foo'
+      }, {
+        'foo': {
+          imports: ['npm:a', 'npm:b']
+        }
+      });
+
+      prePackager.cacheImport(new Import({
+        name: 'a',
+        packageName: 'sample-package',
+        type: 'npm',
+        importer: 'example-app'
+      }), 'example-app');
+
+      prePackager.cacheImport(new Import({
+        name: 'b',
+        packageName: 'sample-package',
+        type: 'npm',
+        importer: 'example-app'
+      }), 'example-app');
+
+      expect(prePackager.importCache).to.deep.eql({
+        npm: {
+          'sample-package': {
+            imports: [
+              new Import({importer: 'example-app', name: 'a', packageName: 'sample-package', type: 'npm'}),
+              new Import({importer: 'example-app', name: 'b', packageName: 'sample-package', type: 'npm'})
+            ],
+            parent: AllDependencies.for('example-app')
+          }
+        }
+      });
+    });
+  });
+
+  describe('diffGraph', function() {
+    it('should perform an idempotent diff if the graphHahes exist and hashes are the same', function() {
+      prePackager.graphHashes = generateGraphHashes();
+
+      prePackager.hashGraphs = function() {
+        return generateGraphHashes();
+      };
+
+      var diffs = prePackager.diffGraph();
+      expect(diffs).to.deep.eql([]);
+    });
+
+    it('should align the graph if an import is removed', function() {
+
+      prePackager.graphHashes = generateGraphHashes();
+      
+      AllDependencies.update({
+        root: process.cwd(),
+        nodeModulesPath: process.cwd() + path.sep + 'node_modules',
+        packageName: 'example-app',
+        pkg: { name: 'example-app', version: '1.0.0' },
+        relativePaths: ['example-app/', 'example-app/a.js', 'example-app/b.js'],
+        parent: null,
+        srcDir: process.cwd() + path.sep + 'tmp_foo'
+      }, prePackager.graphHashes['example-app'].graph);
+
+      AllDependencies.synced('example-app', 'example-app/a.js');
+      AllDependencies.synced('example-app', 'example-app/b.js');
+
+      AllDependencies.for('example-app').descriptor.updateRelativePaths = function() {
+        return ['example-app/', 'example-app/a.js'];
+      };
+
+      prePackager.hashGraphs = function() {
+        return {
+          'example-app': {
+            name: 'example-app',
+            hash: 'c4dedac40c806eb428edc096c4bd6bfb',
+            graph: {
+              'example-app/a' : {
+                imports: []
+              }
+            }
+          }
+        };
+      };
+
+      var diffs = prePackager.diffGraph();
+
+      expect(diffs).to.deep.eql(['example-app']);
+      expect(AllDependencies.getSynced('example-app')).to.deep.eql(['example-app/a.js']);
+      expect(AllDependencies.for('example-app').imports).to.deep.eql({
+        'example-app/a': []
+      });
+      expect(AllDependencies.for('example-app').graph).to.deep.eql({
+        'example-app/a': { imports: [] }
+      });
+    });
+
+    it('should align the graph if an import is added', function() {
+
+      prePackager.graphHashes = generateGraphHashes();
+      
+      AllDependencies.update({
+        root: process.cwd(),
+        nodeModulesPath: process.cwd() + path.sep + 'node_modules',
+        packageName: 'example-app',
+        pkg: { name: 'example-app', version: '1.0.0' },
+        relativePaths: ['example-app/', 'example-app/a.js', 'example-app/b.js'],
+        parent: null,
+        srcDir: process.cwd() + path.sep + 'tmp_foo'
+      }, prePackager.graphHashes['example-app'].graph);
+
+      AllDependencies.synced('example-app', 'example-app/a.js');
+      AllDependencies.synced('example-app', 'example-app/b.js');
+
+      AllDependencies.for('example-app').descriptor.updateRelativePaths = function() {
+        return ['example-app/', 'example-app/a.js', 'example-app/b.js', 'example-app/c.js'];
+      };
+
+      prePackager.hashGraphs = function() {
+        return {
+          'example-app': {
+            name: 'example-app',
+            hash: 'c4dedac40c806eb428edc096c4bd6bfb',
+            graph: {
+              'example-app/a' : {
+                imports: ['example-app/b']
+              },
+              'example-app/b': {
+                imports: ['example-app/c']
+              },
+              'example-app/c': {
+                imports: []
+              }
+            }
+          }
+        };
+      };
+
+      var diffs = prePackager.diffGraph();
+
+      expect(diffs).to.deep.eql(['example-app']);
+      expect(AllDependencies.for('example-app').imports).to.deep.eql({
+        'example-app/a': ['example-app/b'],
+        'example-app/b': ['example-app/c'],
+        'example-app/c': []
+      });
+      
+      expect(AllDependencies.for('example-app').graph).to.deep.eql({
+        'example-app/a': { imports: ['example-app/b'] },
+        'example-app/b': { imports: ['example-app/c'] },
+        'example-app/c': { imports: [] }
+      });
+    });
+
+    it('should perform an idempotent operation if there edges into a dropping edge', function() {
+
+      prePackager.graphHashes = generateGraphHashes();
+      prePackager.graphHashes['foobiz'] = {
+        graph: {
+          'foobiz/foo': {
+            imports: ['example-app/b']
+          }
+        },
+        name: 'foobiz',
+        hash: 'dbd7abe86d2bf760de14681cf990eced'
+      };
+      
+      AllDependencies.update({
+        root: process.cwd(),
+        nodeModulesPath: process.cwd() + path.sep + 'node_modules',
+        packageName: 'example-app',
+        pkg: { name: 'example-app', version: '1.0.0' },
+        relativePaths: ['example-app/', 'example-app/a.js', 'example-app/b.js'],
+        parent: null,
+        srcDir: process.cwd() + path.sep + 'tmp_foo'
+      }, prePackager.graphHashes['example-app'].graph);
+
+      AllDependencies.update({
+        root: process.cwd() + path.sep + 'node_modules' + path.sep + 'foobiz',
+        nodeModulesPath: process.cwd() + path.sep + 'node_modules' + path.sep + 'foobiz' + path.sep + 'node_modules',
+        packageName: 'foobiz',
+        pkg: { name: 'foobiz', version: '1.0.0' },
+        relativePaths: ['foobiz/', 'foobiz/foo.js'],
+        parent: null,
+        srcDir: process.cwd() + path.sep + 'tmp_foobiz'
+      }, prePackager.graphHashes['foobiz'].graph);
+
+      AllDependencies.synced('example-app', 'example-app/a.js');
+      AllDependencies.synced('example-app', 'example-app/b.js');
+      AllDependencies.synced('foobiz', 'foobiz/foo.js');
+
+      AllDependencies.for('example-app').descriptor.updateRelativePaths = function() {
+        return ['example-app/', 'example-app/a.js'];
+      };
+
+      prePackager.hashGraphs = function() {
+        return {
+          'example-app': {
+            name: 'example-app',
+            hash: 'c4dedac40c806eb428edc096c4bd6bfb',
+            graph: {
+              'example-app/a' : {
+                imports: []
+              }
+            }
+          },
+          'foobiz': {
+            name: 'foobiz',
+            hash: 'dbd7abe86d2bf760de14681cf990eced',
+            graph: {
+              'foobiz/foo': {
+                imports: ['example-app/b']
+              }
+            }
+          }
+        };
+      };
+
+      // Asserting example-app/b.js is here from the revious resolve 
+      expect(AllDependencies.getSynced()).to.deep.eql({
+        'example-app': ['example-app/a.js', 'example-app/b.js'],
+        foobiz: ['foobiz/foo.js']
+      });
+
+      var diffs = prePackager.diffGraph();
+
+      // Simulating the edge being placed back in by resolving foobiz/foo
+      AllDependencies.synced('example-app', 'example-app/b.js');
+
+      expect(diffs).to.deep.eql(['example-app']);
+      expect(AllDependencies.getSynced()).to.deep.eql({
+        'example-app': ['example-app/a.js', 'example-app/b.js'],
+        foobiz: ['foobiz/foo.js']
+      });
+    });
+  });
+});


### PR DESCRIPTION
Prior to this refactoring we would resolve the graph on every single rebuild. While this works it is extremely expensive. To combat this we need to diff between rebuilds to determine how the dependency graph has changed.

[Video Of Rebuilds](https://www.youtube.com/watch?v=fObF5W4dvCk)
### Idempotent Rebuilds

In the event there is no change to the graph, it performs an idempotent rebuild, simply syncing forward all imports that were in the graph on the previous rebuild.  It performs the idempotent check by conferring against a map of hashes that represent the dep-graph.json. Since the `dep-graph.json` is immutable (generated on each rebuild) we can reliably use the hashed graph as the initial cache key.  If all the hashes are the same we have found our selves at a point were we would end up in an idempotent operation. At this point we can safely symlink all the files from the previous build to the current build output.

If the cache key differs we first check to see if the thing that caused the invalidation was the dropping of an edge. If the edge is dropped, but was not a leaf we find our selves in an idempotent evaluation as there are other edges pointing into the dropped edge.

In my testing this leads to ~30ms spent in the pre-packager. I also believe this is the 60-70% case once an application reaches a certain maturity threshold.
### Sub-graph resolution

In the event the hashes do not match; a portion of our graph is dirty. We know exactly what package caused the graph to dirty due to the fact that hashes are held in a map keyed off the packageName.

```
{
  'dummy', 'c3a88c401275475269d9a37b47038e86',
  'dummy/test': '600e8a46e75f3432a6cf94d9f98c8162',
  'ember': 'b6d89620dbd9ebfa1e641fc72bcf56c9'
 // ...
}
```

This allows us to diff the graph to collect the dirty path and only perform a subset of work to re-align the graph to it's new shape. We are able to find this dirty path by starting from a macro view of the graph and work our way to the changed file. From that point we compare that node's edges against the entire graph. If we are removing this approach allows us to safely prune leaf nodes if no one else is pointing to them.
### Graph Diffing Algorithm

The algorithm for doing so is as follows:
1. If there are no graphHashes resolve entire graph: **done**
2. If the incoming and current hashes equal we are at an idempotent rebuild: **done**
3. If the incoming and existing hashes do not equal update the current hashes: **_continue**_
4. Compare all the imports of each import to determine what file changed: **_continue**_
5. Determine if imports were added or removed: **_continue**_
   - Import removed: **_continue**_
     - Is import removed a leaf node: **_continue**_
       - Remove files from synced cache and mark package as dirty: **_continue**_
       - If it is not a leaf we are at another idempotent rebuild as we can not prune the dependency: **done**
   - Import added: **_continue**_
     - Mark the package as dirty **_continue**_
6. Sync forward all packages not effected by the dirty path **_continue**_
7. Resolve the dirty path **done**
### More Perf

We can potentially further the perf story by using techniques described in https://github.com/stefanpenner/broccoli-persistent-filter
