### PR TITLE
Recursively remove transitive dependencies

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -63,27 +63,61 @@ var AllDependencies = {
     pack.addToImports(importName, imports);
   },
 
-  _removalIntersection: function(filesToRemove) {
-    var packages = Object.keys(this._graph);
+  _collectTransitives: function(filesToRemove, depPath) {
+    var self = this;
+    depPath = depPath || [];
 
-    return flatten(packages.map(function(packageName) {
+    return flatten(filesToRemove.map(function(file) {
+      var packageName = file.split('/').shift();
+      var deps = self._graph[packageName].imports[file];
+      var intersection;
+
+      if (deps.length === 0) {
+        return depPath;
+      }
+
+      intersection = flatten(self._compareAgainstAllImports(function(allImports) {
+        return intersect(allImports, deps);
+      }));
+
+      if (equal(deps, intersection) || intersection.length === 0) {
+        depPath = depPath.concat(intersection);
+        return self._collectTransitives(intersection, depPath);
+      }
+
+      return depPath;
+
+    }, this));
+  },
+
+  _compareAgainstAllImports: function(comparingFn) {
+    var packages = Object.keys(this._graph);
+    return packages.map(function(packageName) {
       var packageImports = this._graph[packageName].imports;
       var allImports = flatten(Object.keys(packageImports).map(function(importName) {
         return packageImports[importName];
       }));
 
+      return comparingFn(allImports);
+    }, this);
+  },
+
+  _removalIntersection: function(filesToRemove) {
+    return flatten(this._compareAgainstAllImports(function(allImports) {
       return intersect(allImports, filesToRemove);
-    }, this));
+    }));
   },
 
   _removeImportsFromSynced: function(removedFileImports) {
       var removalIntersection = this._removalIntersection(removedFileImports);
       var filesToRemove;
+      var transitives;
 
       if (removalIntersection.length > 1 ) {
         filesToRemove = without(removedFileImports, removalIntersection);
       } else {
-        filesToRemove = removedFileImports;
+        transitives = this._collectTransitives(removedFileImports);
+        filesToRemove = removedFileImports.concat(transitives);
       }
 
       var packageNames = filesToRemove.map(function(file) {
@@ -104,7 +138,7 @@ var AllDependencies = {
       }, this);
   },
 
-  _diffSynced: function(packageName, currentImportHash, newImportHash) {
+  _diffSynced: function(packageName, currentImportHash, newImportHash, dependencies) {
     var currentFiles = Object.keys(currentImportHash).sort();
     var newFiles = Object.keys(newImportHash).sort();
     var fileRemoved = currentFiles.length > newFiles.length;
@@ -115,6 +149,7 @@ var AllDependencies = {
     var fileWithUnstableImports = head(currentFiles.filter(function(file) {
       return !equal(currentImportHash[file], newImportHash[file]);
     }));
+    var pack = this._graph[packageName];
 
     if (fileRemoved) {
       var removedFile = head(without(currentFiles, newFiles));
@@ -139,6 +174,11 @@ var AllDependencies = {
         // with the new imports as they are resolved.
       }
     }
+
+    // NOTE:
+    // Only update after the diffing has occured. If we do not we loose the previous state and cannot
+    // effectly diff the graph.
+    pack.updateDependencies(dependencies);
   },
 
   _updateExisting: function(packageName, dependencies) {
@@ -146,11 +186,9 @@ var AllDependencies = {
 
     if (pack) {
       var currentImportsHash = clone(pack.imports);
-      var newImportHash;
-      pack.updateDependencies(dependencies);
-      newImportHash = clone(pack.imports);
+      var newImportHash = Package.flattenImports(dependencies);
 
-      this._diffSynced(packageName, currentImportsHash, newImportHash);
+      this._diffSynced(packageName, currentImportsHash, newImportHash, dependencies);
 
     } else {
       throw new Error('Attempted to update ' + packageName + ' that has never been resolved.');

--- a/lib/utils/array.js
+++ b/lib/utils/array.js
@@ -52,6 +52,11 @@ var contains = (function() {
 })();
 
 function flatten(array) {
+
+  if (array.length === 0) {
+    return [];
+  }
+
   return array.reduce(function(a, b) {
     return a.concat(b);
   });

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -126,6 +126,12 @@ describe('all dependencies unit', function() {
 
     it('should update the graph if imports are removed', function() {
       AllDependencies.update(descriptor, dependencies);
+      AllDependencies.update({ packageName: 'ember' }, {
+        'ember': {
+          'imports': []
+        }
+      });
+
       simulateSync(descriptor);
       var modifiedDependencies = clone(dependencies);
       var desc = AllDependencies.for(descriptor.packageName).descriptor;
@@ -139,8 +145,14 @@ describe('all dependencies unit', function() {
       expect(AllDependencies._graph['example-app'].graph).to.deep.eql(modifiedDependencies);
     });
 
-    it('should update the graph if imports are removed', function() {
+    it('should update the imports if an import is removed', function() {
       AllDependencies.update(descriptor, dependencies);
+      AllDependencies.update({ packageName: 'ember' }, {
+        'ember': {
+          'imports': []
+        }
+      });
+
       simulateSync(descriptor);
       var modifiedDependencies = clone(dependencies);
       var desc = AllDependencies.for(descriptor.packageName).descriptor;
@@ -159,6 +171,11 @@ describe('all dependencies unit', function() {
 
     it('should not remove items from dedupedImports if something else has a pointer into that import', function() {
       AllDependencies.update(descriptor, dependencies);
+      AllDependencies.update({ packageName: 'ember' }, {
+        'ember': {
+          'imports': []
+        }
+      });
       simulateSync(descriptor);
       var modifiedDependencies = clone(dependencies);
       var desc = AllDependencies.for(descriptor.packageName).descriptor;

--- a/tests/unit/pre-packager-test.js
+++ b/tests/unit/pre-packager-test.js
@@ -339,8 +339,8 @@ describe('PrePackager', function () {
     });
 
     it('should drop transitive dependency if the entry node is dropped', function() {
-
       prePackager.graphHashes = generateGraphHashes();
+      prePackager.graphHashes['example-app'].graph['example-app/a'].imports.push('ember');
       prePackager.graphHashes['example-app'].graph['example-app/b'].imports.push('foobiz/foo');
 
       prePackager.graphHashes['foobiz'] = {
@@ -356,11 +356,21 @@ describe('PrePackager', function () {
       prePackager.graphHashes['bar'] = {
         graph: {
           'bar/bar': {
-            imports: []
+            imports: ['ember']
           }
         },
         name: 'bar',
         hash: '9b7c669dd11a0333039ad97cb5a92b17'
+      };
+
+      prePackager.graphHashes['ember'] = {
+        graph: {
+          'ember/ember': {
+            imports: []
+          }
+        },
+        name: 'ember',
+        hash: 'daljk3325jdksl4ajk324923498hjadn32'
       };
 
       AllDependencies.update({
@@ -372,6 +382,17 @@ describe('PrePackager', function () {
         parent: null,
         srcDir: process.cwd() + path.sep + 'tmp_foo'
       }, prePackager.graphHashes['example-app'].graph);
+
+
+      AllDependencies.update({
+        root: process.cwd() + path.sep + 'node_modules' + path.sep + 'ember',
+        nodeModulesPath: process.cwd() + path.sep + 'node_modules' + path.sep + 'ember' + path.sep + 'node_modules',
+        packageName: 'ember',
+        pkg: { name: 'ember', version: '1.0.0' },
+        relativePaths: ['ember/', 'ember/ember.js'],
+        parent: null,
+        srcDir: process.cwd() + path.sep + 'tmp_ember'
+      }, prePackager.graphHashes['ember'].graph);
 
       AllDependencies.update({
         root: process.cwd() + path.sep + 'node_modules' + path.sep + 'foobiz',
@@ -394,6 +415,7 @@ describe('PrePackager', function () {
       }, prePackager.graphHashes['bar'].graph);
 
       AllDependencies.synced('example-app', 'example-app/a.js');
+      AllDependencies.synced('ember', 'ember/ember.js');
       AllDependencies.synced('example-app', 'example-app/b.js');
       AllDependencies.synced('foobiz', 'foobiz/foo.js');
       AllDependencies.synced('bar', 'bar/bar.js');
@@ -409,7 +431,7 @@ describe('PrePackager', function () {
             hash: 'c4dedac40c806eb428edc096c4bd6bfb',
             graph: {
               'example-app/a' : {
-                imports: ['example-app/b']
+                imports: ['example-app/b', 'ember']
               },
               'example-app/b': {
                 imports: []
@@ -428,11 +450,20 @@ describe('PrePackager', function () {
           bar: {
             graph: {
               'bar/bar': {
-                imports: []
+                imports: ['ember']
               }
             },
             name: 'bar',
             hash: '9b7c669dd11a0333039ad97cb5a92b17'
+          },
+          ember: {
+            graph: {
+              'ember/ember': {
+                imports: []
+              }
+            },
+            name: 'ember',
+            hash: 'daljk3325jdksl4ajk324923498hjadn32'
           }
         };
       };
@@ -444,7 +475,8 @@ describe('PrePackager', function () {
 
       expect(diffs).to.deep.eql(['example-app']);
       expect(AllDependencies.getSynced()).to.deep.eql({
-        'example-app': ['example-app/a.js', 'example-app/b.js']
+        'example-app': ['example-app/a.js', 'example-app/b.js'],
+        ember: ['ember/ember.js']
       });
     });
   });


### PR DESCRIPTION
Prior to this commit I was not actually walking the graph and pruning away the transitive dependencies. When a file is removed we first compare that file against the entire graph, if no one has an edge into it we then look at it's imports and compare them against the graph. We recurse until there are either no more imports or we get to the point where an edge is running into a dependency.  We then take all of the imports up to that point and set them up for removal.
