### PR TITLE
Update babel

### DIFF
--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -9,6 +9,43 @@ var Descriptor      = require('../models/descriptor');
 var quickTemp       = require('quick-temp');
 var syncForwardDependencies = require('../utils/sync-forward-dependencies');
 
+function mungeMetaData(metadata) {
+  return {
+    imports: metadata.imports.map(function(importInfo) {
+      return importInfo.source;
+    })
+  };
+}
+
+
+function moduleResolve(child, name) {
+  if (child.charAt(0) !== '.') { return child; }
+
+  var parts = child.split('/');
+  var nameParts = name.split('/');
+  var parentBase = nameParts.slice(0, -1);
+
+  for (var i = 0, l = parts.length; i < l; i++) {
+    var part = parts[i];
+
+    if (part === '..') {
+      if (parentBase.length === 0) {
+        throw new Error('Cannot access parent module of root');
+      }
+      parentBase.pop();
+    } else if (part === '.') {
+
+      if (parentBase.length === 0) {
+        parentBase.push(name);
+      }
+
+      continue;
+    } else { parentBase.push(part); }
+  }
+
+  return parentBase.join('/');
+}
+
 module.exports = {
   extension: '.js',
   cache: {},
@@ -24,24 +61,31 @@ module.exports = {
   compileThroughCache: function(source, importName, basePath) {
     var mod;
     var cache = this.cache[importName];
-
     if (!cache || cache.src !== source) {
 
       var transpiled = babel.transform(source, {
-        blacklist: ['es6.modules', 'useStrict'],
+        modules: 'amd',
+        moduleIds: true,
+        moduleId: importName,
+        filename: importName,
         nonStandard: false,
-        highlightCode: false
-      }).code;
+        highlightCode: false,
+        resolveModuleSource: function(moduleSource, fileName) {
+          
+          if (basePath) {
+            return moduleResolve(moduleSource, basePath);
+          }
 
-      mod = esperanto.toAmd(transpiled, {
-        amdName: importName,
-        absolutePaths: true,
-        strict: true
+          return moduleResolve(moduleSource, fileName);
+        }
       });
 
-      if (basePath) {
-        mod.deps.imports = this.setBasePath(mod.deps.imports, basePath);
-      }
+      // TODO 
+      // We need to munge this into what esperanto used to give us
+      // In the future we need to refactor when the builder is passing us
+      // dep-graph.json from babel.
+      mod = mungeMetaData(transpiled.metadata.modules);
+      mod.code = transpiled.code;
       
       this.cache[importName] = {
         mod: mod,
@@ -95,7 +139,7 @@ module.exports = {
       destinationPath = path.join(destination, pkg.name, file);
       tmpPath = tmpModules + path.sep + pkg.name + path.sep + file;
       importPath = path.join(root, file);
-      basePath = path.dirname(relativePath);
+      basePath = path.dirname(relativePath) + path.sep;
     } else {
       file = importName + this.extension;
       relativePath = importName;
@@ -107,7 +151,7 @@ module.exports = {
     mod = this.compileThroughCache(fs.readFileSync(importPath, 'utf8'), importName, basePath);
 
     this.syncForwardDependency(pkg.name, destinationPath, tmpPath, mod.code, relativePath + this.extension);
-    AllDependencies.add(descriptor, relativePath, mod.deps);
+    AllDependencies.add(descriptor, relativePath, mod);
     return AllDependencies.for(relativePath, pkg.name);
   },
 

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -3,7 +3,6 @@
 var AllDependencies = require('../all-dependencies');
 var fs              = require('fs-extra');
 var path            = require('path');
-var esperanto       = require('esperanto');
 var babel           = require('babel-core');
 var Descriptor      = require('../models/descriptor');
 var quickTemp       = require('quick-temp');
@@ -34,11 +33,7 @@ function moduleResolve(child, name) {
       }
       parentBase.pop();
     } else if (part === '.') {
-
-      if (parentBase.length === 0) {
-        parentBase.push(name);
-      }
-
+      
       continue;
     } else { parentBase.push(part); }
   }
@@ -70,6 +65,7 @@ module.exports = {
         filename: importName,
         nonStandard: false,
         highlightCode: false,
+        sourceMaps: true,
         resolveModuleSource: function(moduleSource, fileName) {
           
           if (basePath) {
@@ -86,6 +82,7 @@ module.exports = {
       // dep-graph.json from babel.
       mod = mungeMetaData(transpiled.metadata.modules);
       mod.code = transpiled.code;
+      mod.map = transpiled.map;
       
       this.cache[importName] = {
         mod: mod,
@@ -99,9 +96,16 @@ module.exports = {
     return mod;
   },
 
-  syncForwardDependency: function(packageName, destination, tmpPath, source, importPath) {
+  writeSourceMap: function(destination, sourceMap) {
+    destination = destination.replace(path.extname(destination), '.map');
+    fs.mkdirsSync(path.dirname(destination));
+    fs.writeFileSync(destination, sourceMap);
+  },
+
+  syncForwardDependency: function(packageName, destination, tmpPath, mod, importPath) {
     fs.mkdirsSync(path.dirname(tmpPath));
-    fs.writeFileSync(tmpPath, source);
+    fs.writeFileSync(tmpPath, mod.code);
+    this.writeSourceMap(destination, mod.map);
     syncForwardDependencies(packageName, destination, tmpPath, importPath);
   },
 
@@ -150,7 +154,7 @@ module.exports = {
 
     mod = this.compileThroughCache(fs.readFileSync(importPath, 'utf8'), importName, basePath);
 
-    this.syncForwardDependency(pkg.name, destinationPath, tmpPath, mod.code, relativePath + this.extension);
+    this.syncForwardDependency(pkg.name, destinationPath, tmpPath, mod, relativePath + this.extension);
     AllDependencies.add(descriptor, relativePath, mod);
     return AllDependencies.for(relativePath, pkg.name);
   },

--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
   "author": "Chad Hietala, Stefan Penner, and Ember CLI contributors",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^5.3.3",
+    "babel-core": "^5.5.6",
     "broccoli-kitchen-sink-helpers": "^0.2.7",
     "browserify": "^9.0.3",
     "core-object": "^1.1.0",
     "debug": "^2.1.3",
-    "esperanto": "git://github.com/chadhietala/esperanto#dep-export",
     "fs-extra": "^0.17.0",
     "hash-for-dep": "0.0.3",
     "lodash-node": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Chad Hietala, Stefan Penner, and Ember CLI contributors",
   "license": "MIT",
   "dependencies": {
-    "babel-core": "^5.5.6",
+    "babel-core": "^5.5.8",
     "broccoli-kitchen-sink-helpers": "^0.2.7",
     "browserify": "^9.0.3",
     "core-object": "^1.1.0",

--- a/tests/acceptance/pre-package-test.js
+++ b/tests/acceptance/pre-package-test.js
@@ -69,8 +69,11 @@ describe('pre-package acceptance', function () {
         'example-app/tests/dep-graph.json',
         'example-app/tests/unit/components/foo-bar-test.js',
         'lodash/lib/array/flatten.js',
+        'lodash/lib/array/flatten.map',
         'lodash/lib/array/uniq.js',
-        'lodash/lib/compat.js'
+        'lodash/lib/array/uniq.map',
+        'lodash/lib/compat.js',
+        'lodash/lib/compat.map'
       ]);
     });
   });

--- a/tests/unit/es-test.js
+++ b/tests/unit/es-test.js
@@ -52,6 +52,7 @@ describe('es resolver', function() {
     resolver.resolve(tempDir, importInfo, {
       treeDescriptors: generateTreeDescriptors(paths)
     });
+
     expect(resolver.syncForwardDependency.callCount).to.eql(4);
     expect(resolver.syncForwardDependency.firstCall.args[4]).to.eql('lodash/lib/lodash.js');
     expect(resolver.syncForwardDependency.secondCall.args[4]).to.eql('lodash/lib/array/uniq.js');


### PR DESCRIPTION
Prior to this commit we used both esperanto and babel for compilation.  While this worked it left us in a place where we could not generate sourcemaps back into the source.  We also had 2 plugins that did module compilation.

There is a TODO here as I need to refactor the rest of the code to account for the more detailed module info provided by Babel.
