### PR TITLE
Introduce whitelist packages

### DIFF
--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -14,6 +14,7 @@ var helpers                 = require('broccoli-kitchen-sink-helpers');
 var symlinkOrCopySync       = require('symlink-or-copy').sync;
 var stringify               = require('json-stable-stringify');
 var zip                     = array.zip;
+var uniq                    = array.uniq;
 var without                 = array.without;
 
 module.exports = CoreObject.extend({
@@ -27,6 +28,11 @@ module.exports = CoreObject.extend({
     this.importCache = {};
     this.graphHashes = {};
     this.description = 'Ember CLI Pre-Packager';
+    this.whitelist = ['__packager__', 'loader.js', 'ember-cli-shims'];
+
+    if (Array.isArray(options.whitelist)) {
+      this.whitelist = uniq(this.whitelist.concat(options.whitelist));
+    }
 
     if (!this.options.entries) {
       throw new Error('You must pass an array of entries.');
@@ -188,16 +194,11 @@ module.exports = CoreObject.extend({
    */
   syncForwardNonGraphAssets: function() {
     var self = this;
-    // TODO
-    // Having this here sucks because are now bleeding details about
-    // the input to the pre-packager. Consider using a whitelist. While this
-    // feels weird it is a path for `app.import` migration path.
-    var whitelist = ['__packager__', 'loader.js', 'ember-cli-shims'];
     zip(this.inputTrees, this.inputPaths).filter(function(treeAndPath) {
       var tree = treeAndPath[0];
       var name = tree.name;
-      return (!name || whitelist.indexOf(name) > -1);
-    }).map(function(treeAndPath) {
+      return (!name || this.whitelist.indexOf(name) > -1);
+    }, this).map(function(treeAndPath) {
       return [treeAndPath[1], walkSync(treeAndPath[1])];
     }).forEach(function (treeAndPath) {
       var srcDir = treeAndPath[0];


### PR DESCRIPTION
For backwards compatibility, we must supply a path for modules to skip the resolution phase for JavaScript.  Non-js assets are already passed forward so those should continue to work with the app.import API as long as the Builder places those assets into a tree.
