### PR TITLE
Enforce jsnext conventions

### DIFF
--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -89,8 +89,13 @@ module.exports = {
     var basePath;
     var tmpPath;
 
+
+    if (!pkg['jsnext:main']) {
+      throw new Error('You attempted to resolve "' + importName + '" from the "' + packageName + '" package. To accurately resolve ES6 modules, the package must provide a "jsnext:main" key in it\'s package.json.');
+    }
+
     if (isMain) {
-      file = pkg['jsnext:main'] || pkg.main;
+      file = pkg['jsnext:main'];
       relativePath = packageName + '/' + file.replace(path.extname(file), '');
       destinationPath = path.join(destination, pkg.name, file);
       tmpPath = tmpModules + path.sep + pkg.name + path.sep + file;

--- a/tests/fixtures/example-app/node_modules/ember/node_modules/lodash/package.json
+++ b/tests/fixtures/example-app/node_modules/ember/node_modules/lodash/package.json
@@ -1,5 +1,5 @@
 {
   "name": "lodash",
-  "jsnext:main": "lib/lodash.js",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "jsnext:main": "lib/lodash.js"
 }


### PR DESCRIPTION
ES6 modules must provide a "jsnext:main" field in the package.json. This is our flag to know if we can in fact safely resolve the module.
