### PR TITLE
General cleanup and use json-stable-stringify

### DIFF
--- a/lib/pre-packager.js
+++ b/lib/pre-packager.js
@@ -12,6 +12,7 @@ var mapSeries               = require('promise-map-series');
 var getImportInfo           = require('./utils/get-import-info');
 var helpers                 = require('broccoli-kitchen-sink-helpers');
 var symlinkOrCopySync       = require('symlink-or-copy').sync;
+var stringify               = require('json-stable-stringify');
 var zip                     = array.zip;
 var without                 = array.without;
 
@@ -24,9 +25,8 @@ module.exports = CoreObject.extend({
     this.inputTrees = inputTrees;
     this.options = options || {};
     this.importCache = {};
-    this.description = 'Ember CLI Pre-Packager';
-    this.trees = {};
     this.graphHashes = {};
+    this.description = 'Ember CLI Pre-Packager';
 
     if (!this.options.entries) {
       throw new Error('You must pass an array of entries.');
@@ -84,7 +84,11 @@ module.exports = CoreObject.extend({
 
       if (fs.existsSync(depGraphPath)) {
         graph = fs.readJSONSync(depGraphPath, 'utf8');
-        graphHashes[name] = { name: name, hash: helpers.hashStrings([JSON.stringify(graph)]), graph: graph };
+        graphHashes[name] = {
+          name: name,
+          hash: helpers.hashStrings([stringify(graph)]),
+          graph: graph
+        };
       }
     });
 
@@ -262,19 +266,23 @@ module.exports = CoreObject.extend({
   },
 
   cacheImport: function(importInfo, importer) {
-    if (!this.importCache[importInfo.type]) {
-      this.importCache[importInfo.type] = {};
-      this.importCache[importInfo.type][importInfo.packageName] = {
+    var type = importInfo.type;
+    var packageName = importInfo.packageName;
+    var importCache = this.importCache;
+
+    if (!importCache[type]) {
+      importCache[type] = {};
+      importCache[type][packageName] = {
         imports: [importInfo],
         parent: AllDependencies.for(importer)
       };
-    } else if (!this.importCache[importInfo.type][importInfo.packageName]) {
-      this.importCache[importInfo.type][importInfo.packageName] = {
+    } else if (!importCache[type][packageName]) {
+      importCache[type][packageName] = {
         imports: [importInfo],
         parent: AllDependencies.for(importer)
       };
     } else if (!this._containsImport(importInfo)) {
-      this.importCache[importInfo.type][importInfo.packageName].imports.push(importInfo);
+      importCache[type][packageName].imports.push(importInfo);
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "debug": "^2.1.3",
     "fs-extra": "^0.17.0",
     "hash-for-dep": "0.0.3",
+    "json-stable-stringify": "^1.0.0",
     "lodash-node": "^3.6.0",
     "node-modules-path": "^1.0.1",
     "promise-map-series": "^0.2.1",


### PR DESCRIPTION
Since JSON.stringify is not stable as items in a map can re-order, we must use a "stable" stringify method that ensures the order is consistent. Otherwise when we hash the contents, we may accidentally cash bust based on ordering and order does not matter.
