### PR TITLE
Prevent stackoverflow

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -52,9 +52,8 @@ var AllDependencies = {
   },
 
   isSynced: function(packageName, fileName) {
-    return this._synced[packageName] && this._synced[packageName].indexOf(
-      this._normalizeFileName(fileName)
-    ) > -1;
+    fileName = this._normalizeFileName(fileName);
+    return this._synced[packageName] && this._synced[packageName].indexOf(fileName) > -1;
   },
 
   add: function(descriptor, importName, graph) {

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -69,9 +69,11 @@ module.exports = {
   },
 
   materializeGraph: function(destination, nodeModulesPath, imports, packageName) {
-    imports.forEach(function(imprtName) {
-      var nextImports = this.resolveImport(destination, nodeModulesPath, packageName, imprtName);
-      this.materializeGraph(destination, nodeModulesPath, nextImports, packageName);
+    imports.forEach(function(importName) {
+      if (!AllDependencies.isSynced(packageName, importName)) {
+        var nextImports = this.resolveImport(destination, nodeModulesPath, packageName, importName);
+        this.materializeGraph(destination, nodeModulesPath, nextImports, packageName);
+      }
     }, this);
   },
 

--- a/tests/fixtures/example-app/node_modules/ember/node_modules/lodash/lib/compat.js
+++ b/tests/fixtures/example-app/node_modules/ember/node_modules/lodash/lib/compat.js
@@ -1,0 +1,1 @@
+export default function COMPAT() {}

--- a/tests/unit/es-test.js
+++ b/tests/unit/es-test.js
@@ -4,13 +4,12 @@ var resolver = require('../../lib/resolvers/es');
 var sinon = require('sinon');
 var fs = require('fs-extra');
 var generateTreeDescriptors = require('../helpers/generate-tree-descriptors');
-var walkSync = require('walk-sync');
 var temp = require('quick-temp');
 var Import = require('../../lib/models/import');
 var expect = require('chai').expect;
+var AllDependencies = require('../../lib/all-dependencies');
 
 describe('es resolver', function() {
-  var paths = walkSync('tests/fixtures/example-app/tree');
 
   var treeMeta = [{
       name: 'example-app',
@@ -44,6 +43,7 @@ describe('es resolver', function() {
   });
 
   afterEach(function() {
+    AllDependencies._synced = {};
     resolver.syncForwardDependency.restore();
   });
 
@@ -116,7 +116,7 @@ describe('es resolver', function() {
       var tempDir = temp.makeOrRemake({}, 'es-test');
       var treeDescriptors = generateTreeDescriptors(treeMeta);
 
-      
+
       var willThrow = function() {
         return resolver.resolve(tempDir, importInfo, {
           treeDescriptors: treeDescriptors


### PR DESCRIPTION
Prior to this commit nothing was done to prevent es the resolver from cycling to infinity. This
places the correct guard to bail once a dependency has been completely resolved. Fixes #52 
