### PR TITLE
Remove excessive enumeration within ES resolver

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -262,7 +262,7 @@ var AllDependencies = {
     } else if (isRequestingMainFile) {
       return this._graph[parent].imports[fileOrPackage];
     } else {
-      throw new Error(fileOrPackage + ' cannot be found.');
+      return null;
     }
 
   }

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -353,33 +353,30 @@ module.exports = CoreObject.extend({
    */
   selectResolution: function(importer, imports) {
     return mapSeries(imports, function(importee) {
-      var isLegacy = this.legacyImports.indexOf(importee) > -1;
       var packageName = getPackageName(importee, importer);
-
-      debug('importer: %s, importee: %s, packageName: %s', importer, importee, packageName);
-
-      if (isLegacy) {
-        return this.outputPath;
-      }
-
       var importInfo = getImportInfo(this.treeDescriptors, packageName, importee, importer);
       var type = importInfo.type;
       var resolve = this.resolvers[type].resolve;
-      var isSynced = AllDependencies.isSynced(importInfo.packageName, importee + '.js');
+      var isLegacy = this.legacyImports.indexOf(importee) > -1;
+      var isSynced = AllDependencies.isSynced(importInfo.packageName, importee);
+      var isOpaqueType = this.resolvers[type].resolveLater;
+
+      debug('importer: %s, importee: %s, packageName: %s', importer, importee, packageName);
+
+      this.cacheImport(importInfo, importer);
+
+      if (isOpaqueType || isLegacy || isSynced) {
+        return this.outputPath;
+      }
+
       if (this.resolutionTypes.indexOf(type) < 0) {
         throw new Error('You do not have a resolver for ' + importInfo.type + ' types.');
       }
 
       resolve = this.resolvers[type].resolve;
 
-      this.cacheImport(importInfo, importer);
-
-      if (isSynced) {
-        return this.outputPath;
-      } else if (resolve) {
+      if (!isSynced && resolve) {
         return resolve.call(this.resolvers[type], this.outputPath, importInfo, this);
-      } else if (this.resolvers[type].resolveLater) {
-        return this.outputPath;
       } else {
         throw new Error('No `resolve` or `resolveLater` method on the dependency resolver.');
       }

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -69,28 +69,36 @@ module.exports = {
   },
 
   materializeGraph: function(destination, nodeModulesPath, imports, packageName) {
-    var nonSyncedImports = imports.filter(function(importName) {
-      return AllDependencies.isSynced(packageName, importName);
-    });
-
-    nonSyncedImports.forEach(function(importName) {
+    imports.forEach(function(importName) {
       var nextImports = this.resolveImport(destination, nodeModulesPath, packageName, importName);
       this.materializeGraph(destination, nodeModulesPath, nextImports, packageName);
     }, this);
   },
 
-  resolveImport: function(destination, nodeModulesPath, packageName, importName) {
+  _makeOrLookupDescriptor: function(packageName, nodeModulesPath) {
+    var pack = AllDependencies.for(packageName);
+    if (pack && pack.descriptor) {
+      return pack.descriptor;
+    }
+
     var root = path.join(nodeModulesPath, packageName);
     var pkg = fs.readJSONSync(path.join(root, 'package.json'));
     var importNodeModulesPath = path.join(root, 'node_modules');
     var tmpModules = quickTemp.makeOrReuse(this, 'tmpModules');
-    var descriptor = new Descriptor({
+
+    return new Descriptor({
       root: root,
       pkg: pkg,
       srcDir: tmpModules,
       packageName: pkg.name,
       nodeModulesPath: fs.existsSync(importNodeModulesPath) ? importNodeModulesPath : null
     });
+  },
+
+  resolveImport: function(destination, nodeModulesPath, packageName, importName) {
+    var descriptor = this._makeOrLookupDescriptor(packageName, nodeModulesPath);
+    var pkg = descriptor.pkg;
+    var root = descriptor.root;
     var isMain = packageName === importName;
     var file;
     var relativePath;
@@ -108,14 +116,14 @@ module.exports = {
       file = pkg['jsnext:main'];
       relativePath = packageName + '/' + file.replace(path.extname(file), '');
       destinationPath = path.join(destination, pkg.name, file);
-      tmpPath = tmpModules + path.sep + pkg.name + path.sep + file;
+      tmpPath = this.tmpModules + path.sep + pkg.name + path.sep + file;
       importPath = path.join(root, file);
       basePath = path.dirname(relativePath) + path.sep;
     } else {
       file = importName + this.extension;
       relativePath = importName;
       destinationPath = path.join(destination, file);
-      tmpPath = tmpModules + path.sep + file;
+      tmpPath = this.tmpModules + path.sep + file;
       importPath = path.join(nodeModulesPath, file);
     }
 
@@ -123,7 +131,10 @@ module.exports = {
 
     this.syncForwardDependency(pkg.name, destinationPath, tmpPath, mod, relativePath + this.extension);
     AllDependencies.add(descriptor, relativePath, mod.metadata.modules);
-    return AllDependencies.for(relativePath, pkg.name);
+
+    return AllDependencies.for(relativePath, pkg.name).filter(function(importName) {
+      return !AllDependencies.isSynced(packageName, importName);
+    });
   },
 
   resolve: function(destDir, importInfo, linker) {

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -69,11 +69,13 @@ module.exports = {
   },
 
   materializeGraph: function(destination, nodeModulesPath, imports, packageName) {
-    imports.forEach(function(importName) {
-      if (!AllDependencies.isSynced(packageName, importName)) {
-        var nextImports = this.resolveImport(destination, nodeModulesPath, packageName, importName);
-        this.materializeGraph(destination, nodeModulesPath, nextImports, packageName);
-      }
+    var nonSyncedImports = imports.filter(function(importName) {
+      return AllDependencies.isSynced(packageName, importName);
+    });
+
+    nonSyncedImports.forEach(function(importName) {
+      var nextImports = this.resolveImport(destination, nodeModulesPath, packageName, importName);
+      this.materializeGraph(destination, nodeModulesPath, nextImports, packageName);
     }, this);
   },
 

--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -8,6 +8,7 @@ var Descriptor      = require('../models/descriptor');
 var quickTemp       = require('quick-temp');
 var syncForwardDependencies = require('../utils/sync-forward-dependencies');
 var amdNameResolver = require('amd-name-resolver');
+var uniq            = require('../utils/array').uniq;
 
 module.exports = {
   extension: '.js',
@@ -69,10 +70,24 @@ module.exports = {
   },
 
   materializeGraph: function(destination, nodeModulesPath, imports, packageName) {
-    imports.forEach(function(importName) {
-      var nextImports = this.resolveImport(destination, nodeModulesPath, packageName, importName);
-      this.materializeGraph(destination, nodeModulesPath, nextImports, packageName);
-    }, this);
+    var nextImports = [];
+
+    if (imports.length === 0) {
+      return;
+    }
+
+    for (var i = 0, l = imports.length; i < l; i++) {
+      var importName = imports[i];
+      nextImports = nextImports.concat(
+        this.resolveImport(destination, nodeModulesPath, packageName, importName)
+      );
+    }
+
+    nextImports = uniq(nextImports).filter(function(importName) {
+      return !AllDependencies.isSynced(packageName, importName);
+    });
+
+    this.materializeGraph(destination, nodeModulesPath, nextImports, packageName);
   },
 
   _makeOrLookupDescriptor: function(packageName, nodeModulesPath) {
@@ -96,6 +111,11 @@ module.exports = {
   },
 
   resolveImport: function(destination, nodeModulesPath, packageName, importName) {
+
+    if (AllDependencies.isSynced(packageName, importName)) {
+      return [];
+    }
+
     var descriptor = this._makeOrLookupDescriptor(packageName, nodeModulesPath);
     var pkg = descriptor.pkg;
     var root = descriptor.root;
@@ -132,9 +152,7 @@ module.exports = {
     this.syncForwardDependency(pkg.name, destinationPath, tmpPath, mod, relativePath + this.extension);
     AllDependencies.add(descriptor, relativePath, mod.metadata.modules);
 
-    return AllDependencies.for(relativePath, pkg.name).filter(function(importName) {
-      return !AllDependencies.isSynced(packageName, importName);
-    });
+    return AllDependencies.for(relativePath, pkg.name);
   },
 
   resolve: function(destDir, importInfo, linker) {

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -330,11 +330,9 @@ describe('all dependencies unit', function() {
       expect(imports).to.deep.equal(['npm:jquery', 'ember']);
     });
 
-    it('should return throw if the file or package cannot be found', function() {
+    it('should return null if the file or package cannot be found', function() {
       AllDependencies.update(descriptor, dependencies);
-      expect(function() {
-        return AllDependencies.for('dummy/router', 'dummy');
-      }).to.throw(/dummy\/router cannot be found./);
+      expect(AllDependencies.for('dummy/router', 'dummy')).to.eql(null);
     });
   });
 

--- a/tests/unit/es-test.js
+++ b/tests/unit/es-test.js
@@ -44,6 +44,7 @@ describe('es resolver', function() {
 
   afterEach(function() {
     AllDependencies._synced = {};
+    AllDependencies._graph = {};
     resolver.syncForwardDependency.restore();
   });
 


### PR DESCRIPTION
This still is not very fast... but this does reduce some work.

**Update**

After further investigation the time spent in resolving is related to Babel.  Lodash is 416 files and the aggregate time transpile time is ~3800 - 4000ms.
