### PR TITLE
Make ES Resolver Async

### DIFF
--- a/lib/resolvers/es.js
+++ b/lib/resolvers/es.js
@@ -9,6 +9,7 @@ var quickTemp       = require('quick-temp');
 var syncForwardDependencies = require('../utils/sync-forward-dependencies');
 var amdNameResolver = require('amd-name-resolver');
 var uniq            = require('../utils/array').uniq;
+var RSVP            = require('rsvp');
 
 module.exports = {
   extension: '.js',
@@ -23,37 +24,37 @@ module.exports = {
   },
 
   compileThroughCache: function(source, importName, basePath) {
-    var transpiled;
     var cache = this.cache[importName];
+    var self = this;
     if (!cache || cache.src !== source) {
+      return new RSVP.Promise(function(resolve) {
+        var transpiled = babel.transform(source, {
+          modules: 'amd',
+          moduleIds: true,
+          moduleId: importName,
+          filename: importName,
+          nonStandard: false,
+          highlightCode: false,
+          sourceMaps: true,
+          resolveModuleSource: function(moduleSource, fileName) {
+            if (basePath) {
+              return amdNameResolver(moduleSource, basePath);
+            }
 
-      transpiled = babel.transform(source, {
-        modules: 'amd',
-        moduleIds: true,
-        moduleId: importName,
-        filename: importName,
-        nonStandard: false,
-        highlightCode: false,
-        sourceMaps: true,
-        resolveModuleSource: function(moduleSource, fileName) {
-          if (basePath) {
-            return amdNameResolver(moduleSource, basePath);
+            return amdNameResolver(moduleSource, fileName);
           }
+        });
 
-          return amdNameResolver(moduleSource, fileName);
-        }
+        self.cache[importName] = {
+          mod: transpiled,
+          src: source
+        };
+
+        resolve(transpiled);
       });
-
-      this.cache[importName] = {
-        mod: transpiled,
-        src: source
-      };
-
-    } else {
-      transpiled = cache.mod;
     }
 
-    return transpiled;
+    return RSVP.Promise.resolve(cache.mod);
   },
 
   writeSourceMap: function(destination, sourceMap) {
@@ -69,25 +70,41 @@ module.exports = {
     syncForwardDependencies(packageName, destination, tmpPath, importPath);
   },
 
-  materializeGraph: function(destination, nodeModulesPath, imports, packageName) {
-    var nextImports = [];
+  materializeGraph: function(destination, nodeModulesPath, importPromise, packageName) {
+    var self = this;
+    return importPromise.then(function(imports) {
+      if (imports.length === 0) {
+        return;
+      }
 
-    if (imports.length === 0) {
-      return;
-    }
+      var nextImports = [];
+      var currentImports = [];
 
-    for (var i = 0, l = imports.length; i < l; i++) {
-      var importName = imports[i];
-      nextImports = nextImports.concat(
-        this.resolveImport(destination, nodeModulesPath, packageName, importName)
-      );
-    }
+      function addToNextImports(_nextImports) {
+        nextImports = nextImports.concat(_nextImports);
+      }
 
-    nextImports = uniq(nextImports).filter(function(importName) {
-      return !AllDependencies.isSynced(packageName, importName);
+      function materialize() {
+        nextImports = RSVP.Promise.resolve(uniq(nextImports).filter(function(importName) {
+          return !AllDependencies.isSynced(packageName, importName);
+        }));
+        return self.materializeGraph(
+          destination,
+          nodeModulesPath,
+          nextImports,
+          packageName);
+      }
+
+      imports.forEach(function(importName) {
+        currentImports.push(self.resolveImport(
+          destination,
+          nodeModulesPath,
+          packageName,
+          importName).then(addToNextImports));
+      });
+
+      return RSVP.Promise.all(currentImports).then(materialize);
     });
-
-    this.materializeGraph(destination, nodeModulesPath, nextImports, packageName);
   },
 
   _makeOrLookupDescriptor: function(packageName, nodeModulesPath) {
@@ -111,11 +128,11 @@ module.exports = {
   },
 
   resolveImport: function(destination, nodeModulesPath, packageName, importName) {
-
     if (AllDependencies.isSynced(packageName, importName)) {
       return [];
     }
 
+    var self = this;
     var descriptor = this._makeOrLookupDescriptor(packageName, nodeModulesPath);
     var pkg = descriptor.pkg;
     var root = descriptor.root;
@@ -124,7 +141,6 @@ module.exports = {
     var relativePath;
     var destinationPath;
     var importPath;
-    var mod;
     var basePath;
     var tmpPath;
 
@@ -147,12 +163,22 @@ module.exports = {
       importPath = path.join(nodeModulesPath, file);
     }
 
-    mod = this.compileThroughCache(fs.readFileSync(importPath, 'utf8'), importName, basePath);
+    function syncAndCollectDependencies(mod) {
+      self.syncForwardDependency(
+        pkg.name,
+        destinationPath,
+        tmpPath,
+        mod,
+        relativePath + self.extension);
 
-    this.syncForwardDependency(pkg.name, destinationPath, tmpPath, mod, relativePath + this.extension);
-    AllDependencies.add(descriptor, relativePath, mod.metadata.modules);
+      AllDependencies.add(descriptor, relativePath, mod.metadata.modules);
+      return AllDependencies.for(relativePath, pkg.name);
+    }
 
-    return AllDependencies.for(relativePath, pkg.name);
+    return this.compileThroughCache(
+      fs.readFileSync(importPath, 'utf8'),
+      importName,
+      basePath).then(syncAndCollectDependencies);
   },
 
   resolve: function(destDir, importInfo, linker) {
@@ -161,6 +187,6 @@ module.exports = {
     var importName = importInfo.name;
     var packageName = importInfo.packageName;
     var nextImports = this.resolveImport(destDir, nodeModulesPath, packageName, importName);
-    this.materializeGraph(destDir, nodeModulesPath, nextImports, packageName);
+    return this.materializeGraph(destDir, nodeModulesPath, nextImports, packageName);
   }
 };

--- a/tests/unit/es-test.js
+++ b/tests/unit/es-test.js
@@ -58,14 +58,14 @@ describe('es resolver', function() {
 
     var tempDir = temp.makeOrRemake({}, 'es-test');
 
-    resolver.resolve(tempDir, importInfo, {
+    return resolver.resolve(tempDir, importInfo, {
       treeDescriptors: generateTreeDescriptors(treeMeta)
+    }).then(function() {
+      expect(resolver.syncForwardDependency.callCount).to.eql(3);
+      expect(resolver.syncForwardDependency.firstCall.args[4]).to.eql('lodash/lib/array/uniq.js');
+      expect(resolver.syncForwardDependency.secondCall.args[4]).to.eql('lodash/lib/array/flatten.js');
+      expect(resolver.syncForwardDependency.thirdCall.args[4]).to.eql('lodash/lib/compat.js');
     });
-
-    expect(resolver.syncForwardDependency.callCount).to.eql(3);
-    expect(resolver.syncForwardDependency.firstCall.args[4]).to.eql('lodash/lib/array/uniq.js');
-    expect(resolver.syncForwardDependency.secondCall.args[4]).to.eql('lodash/lib/array/flatten.js');
-    expect(resolver.syncForwardDependency.thirdCall.args[4]).to.eql('lodash/lib/compat.js');
   });
 
   it('should sync forward main file it\'s imports', function() {
@@ -78,15 +78,15 @@ describe('es resolver', function() {
 
     var tempDir = temp.makeOrRemake({}, 'es-test');
 
-    resolver.resolve(tempDir, importInfo, {
+    return resolver.resolve(tempDir, importInfo, {
       treeDescriptors: generateTreeDescriptors(treeMeta)
+    }).then(function() {
+      expect(resolver.syncForwardDependency.callCount).to.eql(4);
+      expect(resolver.syncForwardDependency.firstCall.args[4]).to.eql('lodash/lib/lodash.js');
+      expect(resolver.syncForwardDependency.secondCall.args[4]).to.eql('lodash/lib/array/uniq.js');
+      expect(resolver.syncForwardDependency.thirdCall.args[4]).to.eql('lodash/lib/array/flatten.js');
+      expect(resolver.syncForwardDependency.lastCall.args[4]).to.eql('lodash/lib/compat.js');
     });
-
-    expect(resolver.syncForwardDependency.callCount).to.eql(4);
-    expect(resolver.syncForwardDependency.firstCall.args[4]).to.eql('lodash/lib/lodash.js');
-    expect(resolver.syncForwardDependency.secondCall.args[4]).to.eql('lodash/lib/array/uniq.js');
-    expect(resolver.syncForwardDependency.thirdCall.args[4]).to.eql('lodash/lib/array/flatten.js');
-    expect(resolver.syncForwardDependency.lastCall.args[4]).to.eql('lodash/lib/compat.js');
   });
 
   describe('enforce jsnext:main conventions', function() {


### PR DESCRIPTION
By making the ES resolver async we can parallelize each layer of resolution. This yields a 200ms gain in testing the lodash main file.
