### PR TITLE
Always use the name of the tree descriptor

### DIFF
--- a/lib/all-dependencies.js
+++ b/lib/all-dependencies.js
@@ -3,7 +3,6 @@
 var Package       = require('./models/package');
 var array         = require('./utils/array');
 var debug         = require('debug')('pre-packager');
-var path          = require('path');
 var graphlib      = require('graphlib');
 var Graph         = graphlib.Graph;
 var without       = array.without;
@@ -377,7 +376,7 @@ var AllDependencies = {
     if (arguments.length === 1 && typeof arguments[0] !== 'object') {
       throw Error('You must pass a descriptor and a dependency graph.');
     }
-    var name = descriptor.packageName;
+    var name = descriptor.name;
 
     debug('updating graph with: %s', name);
 

--- a/lib/linker.js
+++ b/lib/linker.js
@@ -244,12 +244,12 @@ Linker.prototype._updateDepGraphs = function(diffs) {
       throw new Error('missing [' + treeName + ']');
     }
 
-    var packageName = desc.packageName;
+    var name = desc.name;
     var graphPath = path.join(desc.srcDir, 'dep-graph.json');
     var depgraph = fs.readJSONSync(graphPath);
 
     AllDependencies.update(desc, depgraph);
-    this.syncForwardRoot(packageName);
+    this.syncForwardRoot(name);
   }, this);
 };
 
@@ -362,10 +362,11 @@ Linker.prototype.syncForwardRoot = function(packageName) {
 Linker.prototype.resolve = function(packageNames) {
   return RSVP.Promise.all(packageNames.map(function(packageName) {
     var desc = this.treeDescriptors[packageName];
+
     if (!desc) {
       throw new Error('missing treeDescriptor: [' + packageName + ']');
     }
-    var name = desc.packageName;
+    var name = desc.name;
     var topLevelImports = Object.keys(AllDependencies.for(name).imports);
 
     var resolutions = topLevelImports.map(function(importName) {

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -97,6 +97,7 @@ describe('all dependencies unit', function() {
     descriptor = {
       root: '/workspace/example-app',
       packageName: 'example-app',
+      name: 'example-app',
       srcDir: 'foo/bar/baz_tmp',
       nodeModulesPath: '/workspace/example-app/node_modules',
       pkg: {

--- a/tests/unit/linker-test.js
+++ b/tests/unit/linker-test.js
@@ -116,10 +116,10 @@ describe('Linker', function () {
       var graphs = linker._graphs;
 
       AllDependencies.setRoots(['example-app']);
-      AllDependencies.update({ packageName: 'example-app' }, graphs['example-app'].denormalizedGraph);
+      AllDependencies.update({ name: 'example-app' }, graphs['example-app'].denormalizedGraph);
 
       AllDependencies.addNode('example-app/b', {
-        packageName: 'example-app'
+        name: 'example-app'
       });
 
       AllDependencies.for('example-app').descriptor.updateRelativePaths = function() {};
@@ -147,10 +147,10 @@ describe('Linker', function () {
 
 
       expect(diffs).to.deep.eql([exampleApp]);
-      AllDependencies.update({packageName: 'example-app'}, exampleApp.denormalizedGraph);
+      AllDependencies.update({name: 'example-app'}, exampleApp.denormalizedGraph);
 
       AllDependencies.addNode('example-app/a', {
-        packageName: 'example-app'
+        name: 'example-app'
       });
 
       expect(AllDependencies.graph.nodes()).to.deep.eql(['example-app/a']);
@@ -172,7 +172,7 @@ describe('Linker', function () {
       linker._graphs = generateGraphs();
       var graphs = linker._graphs;
 
-      AllDependencies.update({ packageName: 'example-app' }, graphs['example-app'].denormalizedGraph);
+      AllDependencies.update({ name: 'example-app' }, graphs['example-app'].denormalizedGraph);
 
       AllDependencies.for('example-app').descriptor.updateRelativePaths = function() {};
 
@@ -204,15 +204,15 @@ describe('Linker', function () {
       };
 
       AllDependencies.sync('example-app/a', ['example-app/b'], {
-        packageName: 'example-app'
+        name: 'example-app'
       });
 
       AllDependencies.sync('example-app/b', ['example-app/c'], {
-        packageName: 'example-app'
+        name: 'example-app'
       });
 
       AllDependencies.sync('example-app/c', [], {
-        packageName: 'example-app'
+        name: 'example-app'
       });
 
       linker._graphsByName = function() {
@@ -224,7 +224,7 @@ describe('Linker', function () {
       var diffs = linker.diffGraph();
 
       expect(diffs).to.deep.eql([exampleApp]);
-      AllDependencies.update({packageName: 'example-app'}, exampleApp.denormalizedGraph);
+      AllDependencies.update({name: 'example-app'}, exampleApp.denormalizedGraph);
       expect(AllDependencies.for('example-app').imports).to.deep.eql({
         'example-app/a': ['example-app/b'],
         'example-app/b': ['example-app/c'],
@@ -261,20 +261,20 @@ describe('Linker', function () {
       };
 
       updatePackages([
-        [{packageName: 'foobiz'}, graphs.foobiz.denormalizedGraph],
-        [{packageName: 'example-app'}, graphs['example-app'].denormalizedGraph]
+        [{name: 'foobiz'}, graphs.foobiz.denormalizedGraph],
+        [{name: 'example-app'}, graphs['example-app'].denormalizedGraph]
       ]);
 
       AllDependencies.sync('example-app/a', ['example-app/b'], {
-        packageName: 'example-app'
+        name: 'example-app'
       });
 
       AllDependencies.sync('example-app/b', [], {
-        packageName: 'example-app'
+        name: 'example-app'
       });
 
       AllDependencies.sync('foobiz/foo', ['example-app/b'], {
-        packageName: 'foobiz'
+        name: 'foobiz'
       });
 
 
@@ -354,7 +354,7 @@ describe('Linker', function () {
 
       graphs.ember = {
         denormalizedGraph: {
-          'ember': {
+          ember: {
             exports: {
               exported: [],
               specifiers: []
@@ -366,30 +366,31 @@ describe('Linker', function () {
       };
 
       updatePackages([
-        [{packageName: 'ember'}, graphs.ember.denormalizedGraph],
-        [{packageName: 'example-app'}, graphs['example-app'].denormalizedGraph],
-        [{packageName: 'foobiz'}, graphs.foobiz.denormalizedGraph],
-        [{packageName: 'bar'}, graphs.bar.denormalizedGraph]
+        [{name: 'ember'}, graphs.ember.denormalizedGraph],
+        [{name: 'example-app'}, graphs['example-app'].denormalizedGraph],
+        [{name: 'foobiz'}, graphs.foobiz.denormalizedGraph],
+        [{name: 'bar'}, graphs.bar.denormalizedGraph]
       ]);
 
       AllDependencies.sync('example-app/a', ['ember', 'example-app/b'], {
+        name: 'example-app',
         packageName: 'example-app'
       });
 
       AllDependencies.sync('ember', [], {
-        packageName: 'ember'
+        name: 'ember'
       });
 
       AllDependencies.sync('example-app/b', ['foobiz/foo'], {
-        packageName: 'example-app'
+        name: 'example-app'
       });
 
       AllDependencies.sync('foobiz/foo', ['bar/bar'], {
-        packageName: 'foobiz'
+        name: 'foobiz'
       });
 
       AllDependencies.sync('bar/bar', ['ember'], {
-        packageName: 'bar'
+        name: 'bar'
       });
 
       AllDependencies.for('example-app').descriptor.updateRelativePaths = function() {};
@@ -434,7 +435,7 @@ describe('Linker', function () {
       var diffs = linker.diffGraph();
       expect(diffs).to.deep.eql([exampleApp]);
 
-      AllDependencies.update({packageName: 'example-app' }, exampleApp.denormalizedGraph);
+      AllDependencies.update({name: 'example-app' }, exampleApp.denormalizedGraph);
 
       expect(AllDependencies.graph.nodes()).to.deep.eql(['example-app/a', 'ember', 'example-app/b']);
     });


### PR DESCRIPTION
Instead of relying on the package name we should look at the descriptor
name. The reason for this is that you way have multiple descriptors for
a package and you need to disambiguate between the package and the
desciptor which holds information about the trees.
