### PR TITLE
Persist subgraphs to disk

### DIFF
--- a/lib/linker.js
+++ b/lib/linker.js
@@ -152,8 +152,9 @@ Linker.prototype.diffGraph = function() {
   return unstable;
 };
 
-Linker.prototype._buildSubGraphs = function() {
-  this.subgraphs = AllDependencies.graphForEngines();
+Linker.prototype.buildSubGraphs = function() {
+  var subgraph = stringify(AllDependencies.graphForEngines());
+  fs.writeFileSync(path.resolve(this.outputPath, 'sub-graph.json'), subgraph);
 };
 
 Linker.prototype.exportGraph = function() {
@@ -241,7 +242,7 @@ Linker.prototype.build = function() {
   this.initialBuild = false;
   return this.resolve(diffs.map(byName)).then(function() {
     this.exportGraph();
-    this._buildSubGraphs();
+    this.buildSubGraphs();
   }.bind(this));
 };
 

--- a/tests/acceptance/linker-test.js
+++ b/tests/acceptance/linker-test.js
@@ -84,6 +84,7 @@ describe('linker acceptance', function () {
         'lodash/lib/array/flatten.js',
         'lodash/lib/array/uniq.js',
         'lodash/lib/compat.js',
+        'sub-graph.json'
       ]);
 
       var browserified = results.directory + path.sep + 'browserified-bundle.js';
@@ -134,7 +135,8 @@ describe('linker acceptance', function () {
         'example-app/tests/unit/components/foo-bar-test.js',
         'lodash/lib/array/flatten.js',
         'lodash/lib/array/uniq.js',
-        'lodash/lib/compat.js'
+        'lodash/lib/compat.js',
+        'sub-graph.json'
       ]);
 
     });

--- a/tests/unit/all-dependencies-test.js
+++ b/tests/unit/all-dependencies-test.js
@@ -537,6 +537,45 @@ describe('all dependencies unit', function() {
     });
   });
 
+  describe('graphForEngines', function() {
+
+    beforeEach(function() {
+      AllDependencies.roots = ['example-app', 'example-app/tests'];
+    });
+
+    afterEach(function() {
+      AllDependencies.roots = [];
+    });
+
+    it('should return a map of arrays containing the nodes in a subgraph with cross entry deps pruned', function() {
+
+      AllDependencies.roots = ['example-app', 'example-app/tests'];
+
+      AllDependencies.sync('example-app/app', ['ember'], {
+        packageName: 'example-app'
+      });
+
+      AllDependencies.sync('example-app/router', ['ember'], {
+        packageName: 'example-app'
+      });
+
+      AllDependencies.sync('example-app/tests/unit/app', ['example-app/app', 'ember'], {
+        packageName: 'example-app/tests'
+      });
+
+      AllDependencies.sync('ember', [], {
+        packageName: 'ember'
+      });
+
+      expect(AllDependencies.graphForEngines()).to.deep.eql({
+        'shared-by-all': ['ember'],
+        'example-app': ['example-app/router', 'ember', 'example-app/app'],
+        'example-app/tests': ['example-app/tests/unit/app', 'ember']
+      });
+    });
+  });
+
+
   describe('add', function() {
     it('should add an item to the graph via a single import', function() {
       var desc = {

--- a/tests/unit/linker-test.js
+++ b/tests/unit/linker-test.js
@@ -100,43 +100,6 @@ describe('Linker', function () {
     }).to.throw(/You must pass TreeDescriptors that describe the trees in the project./);
   });
 
-  describe('_buildSubGraphs', function() {
-
-    it('should return a map of arrays containing the nodes in a subgraph with cross entry deps pruned', function() {
-      AllDependencies.sync('example-app/app', ['ember'], {
-        packageName: 'example-app'
-      });
-
-      AllDependencies.sync('example-app/router', ['ember'], {
-        packageName: 'example-app'
-      });
-
-      AllDependencies.sync('example-app/tests/unit/app', ['example-app/app', 'ember'], {
-        packageName: 'example-app/tests'
-      });
-
-      AllDependencies.sync('ember', [], {
-        packageName: 'ember'
-      });
-
-      linker = new Linker(trees, {
-        entries: ['example-app', 'example-app/tests'],
-        treeDescriptors: {
-          ordered: orderedDescs,
-          map: descs
-        }
-      });
-
-      linker._buildSubGraphs();
-
-      expect(linker.subgraphs).to.deep.eql({
-        'shared-by-all': ['ember'],
-        'example-app': ['example-app/router', 'ember', 'example-app/app'],
-        'example-app/tests': ['example-app/tests/unit/app', 'ember']
-      });
-    });
-  });
-
   describe('diffGraph', function() {
     it('should perform an idempotent diff if the graphs exist and they are the same', function() {
       linker._graphs = generateGraphs();


### PR DESCRIPTION
To make concating more straightforward downstream drop a sub-graph.json
on disk to read from.
